### PR TITLE
fix: /etc/hostsの空行累積問題を修正

### DIFF
--- a/internal/hosts/hosts.go
+++ b/internal/hosts/hosts.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 )
 
-const hostsFile = "/etc/hosts"
+var hostsFile = "/etc/hosts"
+
 const markerStart = "# kubectl-local-mesh: managed by kubectl-local-mesh"
 const markerEnd = "# kubectl-local-mesh: end"
 
@@ -29,32 +30,31 @@ func AddEntries(hostnames []string) error {
 		return fmt.Errorf("failed to clean up old entries: %w", err)
 	}
 
-	// 新しいエントリを追加
-	f, err := os.OpenFile(hostsFile, os.O_WRONLY|os.O_APPEND, 0644)
+	// 現在のファイル内容を読み込み、正規化
+	lines, err := readAndNormalizeFile()
 	if err != nil {
-		return fmt.Errorf("failed to open %s: %w", hostsFile, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	// マーカー開始
-	if _, err := f.WriteString("\n" + markerStart + "\n"); err != nil {
 		return err
 	}
+
+	// ファイルが空でない場合、1行の空行で区切る
+	if len(lines) > 0 {
+		lines = append(lines, "")
+	}
+
+	// マーカー開始（直接追加、先頭に改行を入れない）
+	lines = append(lines, markerStart)
 
 	// 各ホスト名のエントリを追加
 	for _, hostname := range hostnames {
-		entry := fmt.Sprintf("127.0.0.1 %s\n", hostname)
-		if _, err := f.WriteString(entry); err != nil {
-			return err
-		}
+		entry := fmt.Sprintf("127.0.0.1 %s", hostname)
+		lines = append(lines, entry)
 	}
 
 	// マーカー終了
-	if _, err := f.WriteString(markerEnd + "\n"); err != nil {
-		return err
-	}
+	lines = append(lines, markerEnd)
 
-	return nil
+	// ファイルに書き込み
+	return writeLinesToFile(lines)
 }
 
 // RemoveEntries removes kubectl-local-mesh entries from /etc/hosts
@@ -62,6 +62,10 @@ func RemoveEntries() error {
 	// /etc/hostsを読み込む
 	f, err := os.Open(hostsFile)
 	if err != nil {
+		// ファイルが存在しない場合は何もしない（エラーではない）
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to open %s: %w", hostsFile, err)
 	}
 	defer func() { _ = f.Close() }()
@@ -75,6 +79,10 @@ func RemoveEntries() error {
 
 		if strings.TrimSpace(line) == markerStart {
 			inManagedBlock = true
+			// マーカー開始の直前の空行を削除
+			if len(lines) > 0 && lines[len(lines)-1] == "" {
+				lines = lines[:len(lines)-1]
+			}
 			continue
 		}
 
@@ -93,17 +101,63 @@ func RemoveEntries() error {
 		return err
 	}
 
-	// /etc/hostsに書き戻す
+	// 末尾の空行を正規化
+	lines = normalizeFileEnding(lines)
+
+	// ファイルに書き戻す
+	return writeLinesToFile(lines)
+}
+
+// trimTrailingEmptyLines は、スライスの末尾にある全ての空行を削除する
+func trimTrailingEmptyLines(lines []string) []string {
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// normalizeFileEnding は、末尾の空行を削除する
+// ファイルに書き込む際に各行に"\n"が追加されるため、ここでは末尾の空行を削除するのみ
+func normalizeFileEnding(lines []string) []string {
+	return trimTrailingEmptyLines(lines)
+}
+
+// readAndNormalizeFile は、hostsファイルを読み込み、末尾を正規化する
+func readAndNormalizeFile() ([]string, error) {
+	f, err := os.Open(hostsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to open %s: %w", hostsFile, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return normalizeFileEnding(lines), nil
+}
+
+// writeLinesToFile は、行のスライスをhostsファイルにアトミックに書き込む
+func writeLinesToFile(lines []string) error {
 	tmpFile := hostsFile + ".tmp"
 	out, err := os.Create(tmpFile)
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer func() { _ = out.Close() }()
 	defer func() { _ = os.Remove(tmpFile) }()
 
 	for _, line := range lines {
 		if _, err := out.WriteString(line + "\n"); err != nil {
+			_ = out.Close()
 			return err
 		}
 	}
@@ -112,7 +166,6 @@ func RemoveEntries() error {
 		return err
 	}
 
-	// 一時ファイルを/etc/hostsに上書き
 	if err := os.Rename(tmpFile, hostsFile); err != nil {
 		return fmt.Errorf("failed to replace %s: %w", hostsFile, err)
 	}

--- a/internal/hosts/hosts_test.go
+++ b/internal/hosts/hosts_test.go
@@ -1,0 +1,294 @@
+package hosts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setTestHostsFile は、テスト用の一時ファイルパスを設定し、テスト終了時に元に戻す
+func setTestHostsFile(t *testing.T, path string) {
+	t.Helper()
+	original := hostsFile
+	hostsFile = path
+	t.Cleanup(func() {
+		hostsFile = original
+	})
+}
+
+// TestAddEntries_EmptyFile は、空ファイルへの初回追加をテストする
+func TestAddEntries_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	// 空ファイルを作成
+	if err := os.WriteFile(testFile, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	hostnames := []string{"test.localhost", "api.localhost"}
+
+	if err := AddEntries(hostnames); err != nil {
+		t.Fatalf("AddEntries failed: %v", err)
+	}
+
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("failed to read test file: %v", err)
+	}
+
+	// 期待される内容:
+	// # kubectl-local-mesh: managed by kubectl-local-mesh
+	// 127.0.0.1 test.localhost
+	// 127.0.0.1 api.localhost
+	// # kubectl-local-mesh: end
+	// (最後に1つの改行)
+
+	expected := markerStart + "\n" +
+		"127.0.0.1 test.localhost\n" +
+		"127.0.0.1 api.localhost\n" +
+		markerEnd + "\n"
+
+	if string(content) != expected {
+		t.Errorf("unexpected content:\ngot:\n%q\nwant:\n%q", string(content), expected)
+	}
+}
+
+// TestAddEntries_ExistingContent は、既存内容がある場合のテスト
+func TestAddEntries_ExistingContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	// 既存内容を書き込み
+	initialContent := "127.0.0.1 localhost\n::1 localhost\n"
+	if err := os.WriteFile(testFile, []byte(initialContent), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	hostnames := []string{"test.localhost"}
+
+	if err := AddEntries(hostnames); err != nil {
+		t.Fatalf("AddEntries failed: %v", err)
+	}
+
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("failed to read test file: %v", err)
+	}
+
+	// 期待される内容:
+	// 127.0.0.1 localhost
+	// ::1 localhost
+	// (空行)
+	// # kubectl-local-mesh: managed by kubectl-local-mesh
+	// 127.0.0.1 test.localhost
+	// # kubectl-local-mesh: end
+	// (最後に1つの改行)
+
+	expected := "127.0.0.1 localhost\n" +
+		"::1 localhost\n" +
+		"\n" +
+		markerStart + "\n" +
+		"127.0.0.1 test.localhost\n" +
+		markerEnd + "\n"
+
+	if string(content) != expected {
+		t.Errorf("unexpected content:\ngot:\n%q\nwant:\n%q", string(content), expected)
+	}
+}
+
+// TestRemoveEntries_CleanRemoval は、マーカーブロックの完全削除をテストする
+func TestRemoveEntries_CleanRemoval(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	// 既存内容 + マーカーブロックを書き込み
+	initialContent := "127.0.0.1 localhost\n" +
+		"::1 localhost\n" +
+		"\n" +
+		markerStart + "\n" +
+		"127.0.0.1 test.localhost\n" +
+		markerEnd + "\n"
+
+	if err := os.WriteFile(testFile, []byte(initialContent), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	if err := RemoveEntries(); err != nil {
+		t.Fatalf("RemoveEntries failed: %v", err)
+	}
+
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("failed to read test file: %v", err)
+	}
+
+	// 期待される内容: 元の内容のみ（マーカーブロックと前の空行が削除される）
+	expected := "127.0.0.1 localhost\n::1 localhost\n"
+
+	if string(content) != expected {
+		t.Errorf("unexpected content:\ngot:\n%q\nwant:\n%q", string(content), expected)
+	}
+}
+
+// TestAddRemoveMultipleTimes は、複数回の追加・削除で空行が累積しないことを確認する
+func TestAddRemoveMultipleTimes(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	// 初期内容を書き込み
+	initialContent := "127.0.0.1 localhost\n::1 localhost\n"
+	if err := os.WriteFile(testFile, []byte(initialContent), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	hostnames := []string{"test.localhost", "api.localhost"}
+
+	// 3回繰り返し
+	for i := 0; i < 3; i++ {
+		// 追加
+		if err := AddEntries(hostnames); err != nil {
+			t.Fatalf("iteration %d: AddEntries failed: %v", i, err)
+		}
+
+		// 削除
+		if err := RemoveEntries(); err != nil {
+			t.Fatalf("iteration %d: RemoveEntries failed: %v", i, err)
+		}
+
+		// 内容を確認
+		content, err := os.ReadFile(testFile)
+		if err != nil {
+			t.Fatalf("iteration %d: failed to read test file: %v", i, err)
+		}
+
+		// 期待される内容: 初期内容に戻る（空行が累積しない）
+		if string(content) != initialContent {
+			t.Errorf("iteration %d: content changed:\ngot:\n%q\nwant:\n%q", i, string(content), initialContent)
+		}
+
+		// 空行の数をカウント（デバッグ用）
+		lines := strings.Split(string(content), "\n")
+		emptyCount := 0
+		for _, line := range lines {
+			if line == "" {
+				emptyCount++
+			}
+		}
+
+		// 末尾の1つの改行のみが許容される
+		if emptyCount > 1 {
+			t.Errorf("iteration %d: too many empty lines: %d", i, emptyCount)
+		}
+	}
+}
+
+// TestNormalizeFileEnding は、normalizeFileEnding関数のユニットテスト
+func TestNormalizeFileEnding(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "空スライス",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "末尾に空行なし",
+			input:    []string{"line1", "line2"},
+			expected: []string{"line1", "line2"},
+		},
+		{
+			name:     "末尾に1つの空行",
+			input:    []string{"line1", "line2", ""},
+			expected: []string{"line1", "line2"},
+		},
+		{
+			name:     "末尾に複数の空行",
+			input:    []string{"line1", "line2", "", "", ""},
+			expected: []string{"line1", "line2"},
+		},
+		{
+			name:     "すべて空行",
+			input:    []string{"", "", ""},
+			expected: []string{},
+		},
+		{
+			name:     "途中に空行がある",
+			input:    []string{"line1", "", "line2", ""},
+			expected: []string{"line1", "", "line2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeFileEnding(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("length mismatch: got %d, want %d", len(result), len(tt.expected))
+				return
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("at index %d: got %q, want %q", i, result[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+// TestTrimTrailingEmptyLines は、trimTrailingEmptyLines関数のユニットテスト
+func TestTrimTrailingEmptyLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "空スライス",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "末尾に空行なし",
+			input:    []string{"line1", "line2"},
+			expected: []string{"line1", "line2"},
+		},
+		{
+			name:     "末尾に1つの空行",
+			input:    []string{"line1", "line2", ""},
+			expected: []string{"line1", "line2"},
+		},
+		{
+			name:     "末尾に複数の空行",
+			input:    []string{"line1", "line2", "", "", ""},
+			expected: []string{"line1", "line2"},
+		},
+		{
+			name:     "すべて空行",
+			input:    []string{"", "", ""},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := trimTrailingEmptyLines(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("length mismatch: got %d, want %d", len(result), len(tt.expected))
+				return
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("at index %d: got %q, want %q", i, result[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
close #24 

## 問題点
起動→終了を繰り返すと、/etc/hostsに空行が累積する問題があった。

## 修正内容
1. AddEntries()を改善
   - ファイル全体をスライスで処理
   - 先頭の不要な改行を削除
   - 正規化されたファイルに対して適切に空行を追加

2. RemoveEntries()を改善
   - マーカー開始の直前の空行を削除
   - 末尾の正規化を追加
   - writeLinesToFile()を使用して統一的に書き込み

3. ヘルパー関数を追加
   - trimTrailingEmptyLines(): 末尾の空行を削除
   - normalizeFileEnding(): 末尾を正規化
   - readAndNormalizeFile(): ファイル読み込みと正規化
   - writeLinesToFile(): アトミックな書き込み

4. テストを追加
   - 空ファイルへの追加
   - 既存内容がある場合の追加
   - マーカーブロックの削除
   - 複数回の追加・削除で空行が累積しないことを確認
   - ヘルパー関数のユニットテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)