### PR TITLE
refactor: rename project from kubectl-local-mesh to kubectl-localmesh

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## プロジェクト概要
 
-`kubectl-local-mesh`は、`kubectl port-forward`をベースにしたローカル専用の疑似サービスメッシュツールです。複数のKubernetesサービスに対して、単一のローカルエントリポイントからホストベースのルーティング（HTTP/gRPC）でアクセスできます。
+`kubectl-localmesh`は、`kubectl port-forward`をベースにしたローカル専用の疑似サービスメッシュツールです。複数のKubernetesサービスに対して、単一のローカルエントリポイントからホストベースのルーティング（HTTP/gRPC）でアクセスできます。
 
 **重要な設計原則:**
 - クラスタ側には何もインストールしない（kubectl primitives only）
@@ -91,8 +91,8 @@ Envoy設定の確認とデバッグを支援します。
 
 詳細: `.claude/skills/kubectl-envoy-debugging/SKILL.md`
 
-#### `kubectl-local-mesh-operations` - 起動・運用
-kubectl-local-mesh固有の運用操作を提供します。
+#### `kubectl-localmesh-operations` - 起動・運用
+kubectl-localmesh固有の運用操作を提供します。
 
 **主な機能**:
 - サービスメッシュの起動・停止
@@ -101,21 +101,21 @@ kubectl-local-mesh固有の運用操作を提供します。
 - 依存関係チェック
 - トラブルシューティング
 
-詳細: `.claude/skills/kubectl-local-mesh-operations/SKILL.md`
+詳細: `.claude/skills/kubectl-localmesh-operations/SKILL.md`
 
 ### クイックスタート
 
 ```bash
 # 1. 依存関係チェック
-.claude/skills/kubectl-local-mesh-operations/scripts/check-dependencies.sh
+.claude/skills/kubectl-localmesh-operations/scripts/check-dependencies.sh
 
 # 2. ビルド
 task build
 
 # 3. 起動
-sudo kubectl local-mesh -f services.yaml
+sudo kubectl localmesh -f services.yaml
 # または
-sudo ./bin/kubectl-local_mesh -f services.yaml
+sudo ./bin/kubectl-localmesh -f services.yaml
 ```
 
 ## 設定ファイル形式
@@ -147,7 +147,7 @@ services:
   - `gopkg.in/yaml.v3`: 設定ファイルパース
 
 - **開発ツール (aqua管理):**
-  - `task`: タスクランナー（Taskfile.yml実行）
+  - `task`: タスクランナー（Taskfile.yaml実行）
   - `golangci-lint`: Go静的解析ツール
   - `goreleaser`: リリース自動化ツール
 
@@ -179,7 +179,7 @@ done
 
 ### クリーンアップ
 
-- `run.Run()`は一時ディレクトリ（`kubectl-local-mesh-*`）を作成し、終了時に削除
+- `run.Run()`は一時ディレクトリ（`kubectl-localmesh-*`）を作成し、終了時に削除
 - すべてのport-forwardプロセスは`ctx`のキャンセルで停止
 - Envoyプロセスも`CommandContext`で管理
 
@@ -188,10 +188,10 @@ done
 `internal/hosts/hosts.go`でマーカーコメントを使用した安全な管理:
 
 ```
-# kubectl-local-mesh: managed by kubectl-local-mesh
+# kubectl-localmesh: managed by kubectl-localmesh
 127.0.0.1 users-api.localhost
 127.0.0.1 billing-api.localhost
-# kubectl-local-mesh: end
+# kubectl-localmesh: end
 ```
 
 - `--update-hosts`フラグのデフォルトは`true`

--- a/.claude/skills/go-taskfile-workflow/SKILL.md
+++ b/.claude/skills/go-taskfile-workflow/SKILL.md
@@ -6,12 +6,12 @@ allowed-tools: ["Bash", "Read", "Glob", "Grep"]
 
 # Go Taskfile Workflow
 
-このskillは、Taskfile.ymlを使ったGoプロジェクトの標準開発ワークフローを提供します。
+このskillは、Taskfile.yamlを使ったGoプロジェクトの標準開発ワークフローを提供します。
 
 ## 対象プロジェクト
 
 - Go言語プロジェクト
-- Taskfile.ymlでビルド・テスト・Lintを管理
+- Taskfile.yamlでビルド・テスト・Lintを管理
 - aquaで開発ツールを管理（オプション）
 
 ## 提供機能
@@ -110,7 +110,7 @@ task --list
 aqua install
 
 # またはTaskfileが存在しない場合
-ls Taskfile.yml
+ls Taskfile.yaml
 ```
 
 ### ビルドエラー
@@ -136,5 +136,5 @@ task lint
 
 ## 関連ドキュメント
 
-- プロジェクトのTaskfile.yml: タスク定義の詳細
+- プロジェクトのTaskfile.yaml: タスク定義の詳細
 - プロジェクトのCLAUDE.md: アーキテクチャと実装詳細

--- a/.claude/skills/kubectl-envoy-debugging/SKILL.md
+++ b/.claude/skills/kubectl-envoy-debugging/SKILL.md
@@ -20,13 +20,13 @@ allowed-tools: ["Bash", "Read", "Write", "Glob"]
 生成されたEnvoy設定をYAML形式で確認:
 
 ```bash
-kubectl local-mesh --dump-envoy-config -f services.yaml
+kubectl localmesh --dump-envoy-config -f services.yaml
 
 # ファイルに保存
-kubectl local-mesh --dump-envoy-config -f services.yaml > envoy-config.yaml
+kubectl localmesh --dump-envoy-config -f services.yaml > envoy-config.yaml
 
 # または直接実行
-./kubectl-local-mesh --dump-envoy-config -f services.yaml > envoy-config.yaml
+./kubectl-localmesh --dump-envoy-config -f services.yaml > envoy-config.yaml
 ```
 
 **用途**:
@@ -53,9 +53,9 @@ mocks:
 EOF
 
 # モック設定を使ってダンプ
-kubectl local-mesh --dump-envoy-config -f services.yaml --mock-config mocks.yaml
+kubectl localmesh --dump-envoy-config -f services.yaml --mock-config mocks.yaml
 # または
-./kubectl-local-mesh --dump-envoy-config -f services.yaml --mock-config mocks.yaml
+./kubectl-localmesh --dump-envoy-config -f services.yaml --mock-config mocks.yaml
 ```
 
 **モック設定形式**:
@@ -72,9 +72,9 @@ kubectl local-mesh --dump-envoy-config -f services.yaml --mock-config mocks.yaml
 詳細なデバッグログを出力:
 
 ```bash
-sudo kubectl local-mesh -f services.yaml -log debug
+sudo kubectl localmesh -f services.yaml -log debug
 # または
-sudo ./kubectl-local-mesh -f services.yaml -log debug
+sudo ./kubectl-localmesh -f services.yaml -log debug
 ```
 
 **ログレベル**:
@@ -125,7 +125,7 @@ sudo ./kubectl-local-mesh -f services.yaml -log debug
 
 ```bash
 # 1. 設定をダンプして確認
-./kubectl-local-mesh --dump-envoy-config -f services.yaml > /tmp/envoy-config.yaml
+./kubectl-localmesh --dump-envoy-config -f services.yaml > /tmp/envoy-config.yaml
 
 # 2. Envoy設定を直接検証
 envoy --mode validate -c /tmp/envoy-config.yaml
@@ -135,7 +135,7 @@ envoy --mode validate -c /tmp/envoy-config.yaml
 
 ```bash
 # 1. デバッグログで詳細を確認
-sudo ./kubectl-local-mesh -f services.yaml -log debug
+sudo ./kubectl-localmesh -f services.yaml -log debug
 
 # 2. 別ターミナルでcurlテスト
 curl -v http://users-api.localhost/

--- a/.claude/skills/kubectl-localmesh-operations/SKILL.md
+++ b/.claude/skills/kubectl-localmesh-operations/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: kubectl-local-mesh-operations
-description: kubectl-local-mesh固有の運用操作（起動、/etc/hosts管理、サービスアクセス、依存関係チェック）を提供します
+name: kubectl-localmesh-operations
+description: kubectl-localmesh固有の運用操作（起動、/etc/hosts管理、サービスアクセス、依存関係チェック）を提供します
 allowed-tools: ["Bash", "Read"]
 ---
 
-# kubectl-local-mesh 運用操作
+# kubectl-localmesh 運用操作
 
-このskillは、kubectl-local-mesh固有の運用操作を提供します。
+このskillは、kubectl-localmesh固有の運用操作を提供します。
 
 ## 提供機能
 
@@ -15,16 +15,16 @@ allowed-tools: ["Bash", "Read"]
 **kubectlプラグインとして起動（推奨、/etc/hosts自動更新あり、sudo必要）**:
 
 ```bash
-sudo kubectl local-mesh -f services.yaml
+sudo kubectl localmesh -f services.yaml
 ```
 
 **直接実行の場合**:
 ```bash
 # Task経由でビルド済み、またはgo install済み
-sudo ./bin/kubectl-local_mesh -f services.yaml
+sudo ./bin/kubectl-localmesh -f services.yaml
 
 # 直接go buildした場合
-sudo ./kubectl-local_mesh -f services.yaml
+sudo ./kubectl-localmesh -f services.yaml
 ```
 
 ### /etc/hosts管理オプション
@@ -32,9 +32,9 @@ sudo ./kubectl-local_mesh -f services.yaml
 **自動更新を無効化**:
 
 ```bash
-kubectl local-mesh -f services.yaml --update-hosts=false
+kubectl localmesh -f services.yaml --update-hosts=false
 # または
-./kubectl-local_mesh -f services.yaml --update-hosts=false
+./kubectl-localmesh -f services.yaml --update-hosts=false
 ```
 
 この場合、Hostヘッダーを手動指定:
@@ -81,7 +81,7 @@ grpcurl -plaintext -authority users-api.localhost 127.0.0.1:80 list
 **クリーンな終了を確認**:
 ```bash
 # /etc/hostsにエントリが残っていないか確認
-grep "kubectl-local-mesh" /etc/hosts
+grep "kubectl-localmesh" /etc/hosts
 
 # port-forwardプロセスが残っていないか確認
 ps aux | grep "kubectl port-forward"
@@ -96,7 +96,7 @@ ps aux | grep envoy
 
 ```bash
 # スクリプトを使用
-.claude/skills/kubectl-local-mesh-operations/scripts/check-dependencies.sh
+.claude/skills/kubectl-localmesh-operations/scripts/check-dependencies.sh
 
 # または個別に確認
 kubectl version --client
@@ -137,13 +137,13 @@ kill <PID>
 
 ```bash
 # Envoy設定をダンプ
-./kubectl-local-mesh --dump-envoy-config -f services.yaml > /tmp/envoy-config.yaml
+./kubectl-localmesh --dump-envoy-config -f services.yaml > /tmp/envoy-config.yaml
 
 # Envoy設定を検証
 envoy --mode validate -c /tmp/envoy-config.yaml
 
 # デバッグログで詳細確認
-sudo ./kubectl-local-mesh -f services.yaml -log debug
+sudo ./kubectl-localmesh -f services.yaml -log debug
 ```
 
 #### 問題: port-forward接続失敗
@@ -177,10 +177,10 @@ kubectl get nodes
 
 ```bash
 # sudo権限で実行
-sudo ./kubectl-local-mesh -f services.yaml
+sudo ./kubectl-localmesh -f services.yaml
 
 # または/etc/hosts更新を無効化
-./kubectl-local-mesh -f services.yaml --update-hosts=false
+./kubectl-localmesh -f services.yaml --update-hosts=false
 ```
 
 #### 問題: サービスにアクセスできない
@@ -188,7 +188,7 @@ sudo ./kubectl-local-mesh -f services.yaml
 **症状**: `connection refused`や`503 Service Unavailable`
 
 **解決手順**:
-1. kubectl-local-meshが起動しているか確認
+1. kubectl-localmeshが起動しているか確認
 2. port-forwardが正常に動作しているか確認
 3. Envoyログを確認
 4. curlで詳細なHTTPヘッダーを確認
@@ -230,7 +230,7 @@ curl -v http://users-api.localhost/
 
 ```bash
 # 1. 依存関係チェック
-.claude/skills/kubectl-local-mesh-operations/scripts/check-dependencies.sh
+.claude/skills/kubectl-localmesh-operations/scripts/check-dependencies.sh
 
 # 2. 設定ファイル確認
 cat services.yaml
@@ -239,14 +239,14 @@ cat services.yaml
 kubectl cluster-info
 
 # 4. 起動
-sudo ./bin/kubectl-local-mesh -f services.yaml
+sudo ./bin/kubectl-localmesh -f services.yaml
 ```
 
 ### 日常的な使用
 
 ```bash
 # 1. 起動
-sudo ./bin/kubectl-local-mesh -f services.yaml
+sudo ./bin/kubectl-localmesh -f services.yaml
 
 # 2. 別ターミナルでサービスにアクセス
 curl http://users-api.localhost/health
@@ -259,7 +259,7 @@ grpcurl -plaintext users-api.localhost list
 
 ```bash
 # 1. デバッグモードで起動
-sudo ./kubectl-local-mesh -f services.yaml -log debug
+sudo ./kubectl-localmesh -f services.yaml -log debug
 
 # 2. 問題を再現
 curl http://users-api.localhost/problematic-endpoint
@@ -268,7 +268,7 @@ curl http://users-api.localhost/problematic-endpoint
 # （標準出力に詳細なログが表示される）
 
 # 4. 必要に応じてEnvoy設定を確認
-./kubectl-local-mesh --dump-envoy-config -f services.yaml
+./kubectl-localmesh --dump-envoy-config -f services.yaml
 ```
 
 ## 参考情報

--- a/.claude/skills/kubectl-localmesh-operations/scripts/check-dependencies.sh
+++ b/.claude/skills/kubectl-localmesh-operations/scripts/check-dependencies.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# kubectl-local-mesh 依存関係チェックスクリプト
+# kubectl-localmesh 依存関係チェックスクリプト
 
 set -e
 
 echo "==================================="
-echo "kubectl-local-mesh 依存関係チェック"
+echo "kubectl-localmesh 依存関係チェック"
 echo "==================================="
 echo ""
 
@@ -54,7 +54,7 @@ if kubectl cluster-info &> /dev/null; then
     echo "   現在のコンテキスト: $context"
 else
     echo "⚠️  Kubernetesクラスタに接続できません"
-    echo "   kubectl-local-meshの起動時にエラーになる可能性があります"
+    echo "   kubectl-localmeshの起動時にエラーになる可能性があります"
     echo "   （オフラインモードでのEnvoy設定ダンプは可能）"
 fi
 echo ""
@@ -65,7 +65,7 @@ if [ $exit_code -eq 0 ]; then
     echo "✅ すべての依存関係が満たされています"
     echo ""
     echo "次のステップ:"
-    echo "  sudo ./bin/kubectl-local-mesh -f services.yaml"
+    echo "  sudo ./bin/kubectl-localmesh -f services.yaml"
 else
     echo "❌ 必須の依存関係が不足しています"
     echo "   上記のインストール方法を参照してください"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gomod"  # See documentation for possible values
+    directory: "/"  # Location of package manifests
     schedule:
       interval: "weekly"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-kubectl-local-mesh
+kubectl-localmesh
 main
 bin/
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@
 
 version: 2
 
-project_name: kubectl-local-mesh
+project_name: kubectl-localmesh
 
 before:
   hooks:
@@ -20,8 +20,6 @@ builds:
     goos:
       - linux
       - darwin
-    main: ./cmd/kubectl-local_mesh
-    binary: "kubectl-local_mesh"
 
 archives:
   - formats: [tar.gz]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,26 @@
 # Changelog
 
-## [v0.1.4](https://github.com/usadamasa/kubectl-local-mesh/compare/v0.1.3...v0.1.4) - 2025-12-29
+## [v0.1.4](https://github.com/usadamasa/kubectl-localmesh/compare/v0.1.3...v0.1.4) - 2025-12-29
 ### Other Changes
-- now by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/30
+- now by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/30
 
-## [v0.1.3](https://github.com/usadamasa/kubectl-local-mesh/compare/v0.1.2...v0.1.3) - 2025-12-29
+## [v0.1.3](https://github.com/usadamasa/kubectl-localmesh/compare/v0.1.2...v0.1.3) - 2025-12-29
 ### Bug Fixes 🐛
-- fix: /etc/hostsの空行累積問題を修正 by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/28
-- adopt kubectl plugin naming by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/29
+- fix: /etc/hostsの空行累積問題を修正 by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/28
+- adopt kubectl plugin naming by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/29
 
-## [v0.1.2](https://github.com/usadamasa/kubectl-local-mesh/compare/v0.1.1...v0.1.2) - 2025-12-29
+## [v0.1.2](https://github.com/usadamasa/kubectl-localmesh/compare/v0.1.1...v0.1.2) - 2025-12-29
 ### Bug Fixes 🐛
-- bugfix: fix with golangci-lint by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/17
+- bugfix: fix with golangci-lint by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/17
 
-## [v0.1.1](https://github.com/usadamasa/kubectl-local-mesh/compare/v0.1.0...v0.1.1) - 2025-12-28
-- setup ci by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/11
-- introduce tagpr by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/12
-- run tagpr with gh app token by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/14
+## [v0.1.1](https://github.com/usadamasa/kubectl-localmesh/compare/v0.1.0...v0.1.1) - 2025-12-28
+- setup ci by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/11
+- introduce tagpr by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/12
+- run tagpr with gh app token by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/14
 
-## [v0.1.0](https://github.com/usadamasa/kubectl-local-mesh/commits/v0.1.0) - 2025-12-27
-- [from now] 2025/12/27 17:58:16 by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/2
-- [from now] 2025/12/27 21:59:49 by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/3
-- Make --update-hosts default to true for normal startup by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/4
-- Change default listen port by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/6
-- add ci-status-check by @usadamasa in https://github.com/usadamasa/kubectl-local-mesh/pull/7
+## [v0.1.0](https://github.com/usadamasa/kubectl-localmesh/commits/v0.1.0) - 2025-12-27
+- [from now] 2025/12/27 17:58:16 by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/2
+- [from now] 2025/12/27 21:59:49 by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/3
+- Make --update-hosts default to true for normal startup by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/4
+- Change default listen port by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/6
+- add ci-status-check by @usadamasa in https://github.com/usadamasa/kubectl-localmesh/pull/7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# kubectl-local-mesh
+# kubectl-localmesh
 
-`kubectl-local-mesh` is a **local-only pseudo service mesh** built on top of `kubectl port-forward`.
+`kubectl-localmesh` is a **local-only pseudo service mesh** built on top of `kubectl port-forward`.
 
 It lets you access multiple Kubernetes Services across namespaces through a single local entrypoint, with host-based routing for both HTTP and gRPC, without installing anything into your cluster.
 
@@ -18,7 +18,7 @@ If you have ever done this:
 
 This tool smooths that out.
 
-`kubectl-local-mesh` provides an **ingress/gateway-like experience**, but:
+`kubectl-localmesh` provides an **ingress/gateway-like experience**, but:
 
 - No Ingress
 - No Service Mesh
@@ -71,8 +71,8 @@ v
 ## Installation
 
 ```sh
-go install github.com/jpeach/kubectl-local-mesh@latest
-kubectl local-mesh --help
+go install github.com/jpeach/kubectl-localmesh@latest
+kubectl localmesh --help
 ```
 
 ### Prerequisites
@@ -125,22 +125,22 @@ Notes:
 
 ### Run
 
-By default, kubectl-local-mesh automatically updates `/etc/hosts`, which requires sudo:
+By default, kubectl-localmesh automatically updates `/etc/hosts`, which requires sudo:
 
 ```bash
-sudo kubectl local-mesh -f services.yaml
+sudo kubectl localmesh -f services.yaml
 ```
 
 Or directly:
 
 ```bash
-sudo kubectl-local-mesh services.yaml
+sudo kubectl-localmesh services.yaml
 ```
 
 To disable automatic `/etc/hosts` update:
 
 ```bash
-kubectl local-mesh -f services.yaml --update-hosts=false
+kubectl localmesh -f services.yaml --update-hosts=false
 ```
 
 Example output:
@@ -150,7 +150,7 @@ Example output:
 pf: users-api.localhost -> users/users-api:50051 via 127.0.0.1:43127
 pf: billing-api.localhost -> billing/billing-api:8080 via 127.0.0.1:51234
 
-envoy config: /tmp/kubectl-local-mesh-XXXXXX/envoy.yaml
+envoy config: /tmp/kubectl-localmesh-XXXXXX/envoy.yaml
 listen: 0.0.0.0:80
 ```
 
@@ -177,12 +177,12 @@ gRPC notes
 
 ### /etc/hosts Automatic Management
 
-By default, kubectl-local-mesh automatically updates `/etc/hosts` to enable simple hostname-based access without specifying the Host header.
+By default, kubectl-localmesh automatically updates `/etc/hosts` to enable simple hostname-based access without specifying the Host header.
 
 **Default behavior (requires sudo):**
 
 ```bash
-sudo kubectl local-mesh -f services.yaml
+sudo kubectl localmesh -f services.yaml
 ```
 
 This automatically adds entries like:
@@ -195,7 +195,7 @@ This automatically adds entries like:
 **Disable automatic /etc/hosts update:**
 
 ```bash
-kubectl local-mesh -f services.yaml --update-hosts=false
+kubectl localmesh -f services.yaml --update-hosts=false
 
 # In this case, you need to specify the Host header manually:
 curl -H "Host: users-api.localhost" http://127.0.0.1:80/
@@ -203,7 +203,7 @@ curl -H "Host: users-api.localhost" http://127.0.0.1:80/
 
 **Cleanup:**
 
-When you stop kubectl-local-mesh (Ctrl+C), it automatically removes the managed entries from /etc/hosts.
+When you stop kubectl-localmesh (Ctrl+C), it automatically removes the managed entries from /etc/hosts.
 
 ### Advanced Usage
 
@@ -212,7 +212,7 @@ When you stop kubectl-local-mesh (Ctrl+C), it automatically removes the managed 
 You can dump the generated Envoy configuration to stdout for debugging or inspection:
 
 ```bash
-kubectl local-mesh --dump-envoy-config -f services.yaml
+kubectl localmesh --dump-envoy-config -f services.yaml
 ```
 
 This is useful for:
@@ -243,7 +243,7 @@ mocks:
 EOF
 
 # Dump config using mocks (no cluster connection required)
-kubectl local-mesh --dump-envoy-config -f services.yaml --mock-config mocks.yaml
+kubectl localmesh --dump-envoy-config -f services.yaml --mock-config mocks.yaml
 ```
 
 This is useful for:
@@ -291,7 +291,7 @@ Roadmap ideas
 
 Naming
 
-kubectl-local-mesh means:
+kubectl-localmesh means:
 
 - kubectl: kubectl-native workflow
 - local: strictly local execution

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,7 +6,7 @@ tasks:
   build:
     desc: Build the project
     cmds:
-      - go build -o bin/kubectl-local_mesh cmd/kubectl-local_mesh/main.go
+      - go build -o bin/kubectl-localmesh main.go
 
   test:
     desc: Run tests
@@ -16,7 +16,7 @@ tasks:
   lint:
     desc: Run Linters
     cmds:
-      - yamllint -c .yamllint.yml .
+      - yamllint -c .yamllint.yaml .
       - golangci-lint run
 
   format:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/usadamasa/kubectl-local-mesh
+module github.com/usadamasa/kubectl-localmesh
 
 go 1.25.5
 

--- a/internal/hosts/hosts.go
+++ b/internal/hosts/hosts.go
@@ -9,8 +9,8 @@ import (
 
 var hostsFile = "/etc/hosts"
 
-const markerStart = "# kubectl-local-mesh: managed by kubectl-local-mesh"
-const markerEnd = "# kubectl-local-mesh: end"
+const markerStart = "# kubectl-localmesh: managed by kubectl-localmesh"
+const markerEnd = "# kubectl-localmesh: end"
 
 // HasPermission checks if we can write to /etc/hosts
 func HasPermission() bool {
@@ -57,7 +57,7 @@ func AddEntries(hostnames []string) error {
 	return writeLinesToFile(lines)
 }
 
-// RemoveEntries removes kubectl-local-mesh entries from /etc/hosts
+// RemoveEntries removes kubectl-localmesh entries from /etc/hosts
 func RemoveEntries() error {
 	// /etc/hostsを読み込む
 	f, err := os.Open(hostsFile)

--- a/internal/hosts/hosts_test.go
+++ b/internal/hosts/hosts_test.go
@@ -40,10 +40,10 @@ func TestAddEntries_EmptyFile(t *testing.T) {
 	}
 
 	// 期待される内容:
-	// # kubectl-local-mesh: managed by kubectl-local-mesh
+	// # kubectl-localmesh: managed by kubectl-localmesh
 	// 127.0.0.1 test.localhost
 	// 127.0.0.1 api.localhost
-	// # kubectl-local-mesh: end
+	// # kubectl-localmesh: end
 	// (最後に1つの改行)
 
 	expected := markerStart + "\n" +
@@ -83,9 +83,9 @@ func TestAddEntries_ExistingContent(t *testing.T) {
 	// 127.0.0.1 localhost
 	// ::1 localhost
 	// (空行)
-	// # kubectl-local-mesh: managed by kubectl-local-mesh
+	// # kubectl-localmesh: managed by kubectl-localmesh
 	// 127.0.0.1 test.localhost
-	// # kubectl-local-mesh: end
+	// # kubectl-localmesh: end
 	// (最後に1つの改行)
 
 	expected := "127.0.0.1 localhost\n" +

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -9,11 +9,11 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/usadamasa/kubectl-local-mesh/internal/config"
-	"github.com/usadamasa/kubectl-local-mesh/internal/envoy"
-	"github.com/usadamasa/kubectl-local-mesh/internal/hosts"
-	"github.com/usadamasa/kubectl-local-mesh/internal/kube"
-	"github.com/usadamasa/kubectl-local-mesh/internal/pf"
+	"github.com/usadamasa/kubectl-localmesh/internal/config"
+	"github.com/usadamasa/kubectl-localmesh/internal/envoy"
+	"github.com/usadamasa/kubectl-localmesh/internal/hosts"
+	"github.com/usadamasa/kubectl-localmesh/internal/kube"
+	"github.com/usadamasa/kubectl-localmesh/internal/pf"
 )
 
 func Run(ctx context.Context, cfg *config.Config, logLevel string, updateHosts bool) error {
@@ -21,7 +21,7 @@ func Run(ctx context.Context, cfg *config.Config, logLevel string, updateHosts b
 	if updateHosts {
 		// 権限チェック
 		if !hosts.HasPermission() {
-			return fmt.Errorf("need sudo: try 'sudo kubectl-local-mesh ...'")
+			return fmt.Errorf("need sudo: try 'sudo kubectl-localmesh ...'")
 		}
 
 		// ホスト名リストを収集
@@ -46,7 +46,7 @@ func Run(ctx context.Context, cfg *config.Config, logLevel string, updateHosts b
 		}()
 	}
 
-	tmpDir, err := os.MkdirTemp("", "kubectl-local-mesh-")
+	tmpDir, err := os.MkdirTemp("", "kubectl-localmesh-")
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/usadamasa/kubectl-local-mesh/internal/config"
-	"github.com/usadamasa/kubectl-local-mesh/internal/run"
+	"github.com/usadamasa/kubectl-localmesh/internal/config"
+	"github.com/usadamasa/kubectl-localmesh/internal/run"
 )
 
 func main() {
@@ -26,8 +26,8 @@ func main() {
 		*fConfig = flag.Arg(0)
 	}
 	if *fConfig == "" {
-		fmt.Fprintln(os.Stderr, "usage: kubectl-local-mesh -f services.yaml")
-		fmt.Fprintln(os.Stderr, "   or: kubectl-local-mesh services.yaml")
+		fmt.Fprintln(os.Stderr, "usage: kubectl-localmesh -f services.yaml")
+		fmt.Fprintln(os.Stderr, "   or: kubectl-localmesh services.yaml")
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
- プロジェクト名を kubectl-local-mesh から kubectl-localmesh に変更
- main.go をリポジトリルートに移動（cmd/ ディレクトリ削除）
- go.mod のmodule pathを更新
- /etc/hosts マーカーコメントを kubectl-localmesh に変更
- 一時ディレクトリプレフィックスを kubectl-localmesh- に変更
- すべてのドキュメントとSkillsを更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)