### PR TITLE
Bugfix/handle invalid hosts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -200,7 +200,7 @@ done
 
 ### /etc/hosts自動管理
 
-`internal/hosts/hosts.go`でマーカーコメントを使用した安全な管理:
+`internal/hosts/hosts.go`および`internal/hosts/validate.go`でマーカーコメントを使用した安全な管理:
 
 ```
 # kubectl-localmesh: managed by kubectl-localmesh
@@ -209,11 +209,20 @@ done
 # kubectl-localmesh: end
 ```
 
+**基本動作:**
 - `--update-hosts`フラグのデフォルトは`true`
 - 通常起動時は自動的に/etc/hostsを更新（sudo必要）
 - 終了時（Ctrl+C）に自動クリーンアップ
 - `--dump-envoy-config`モードでは更新しない
 - 一時ファイル経由で安全に書き換え
+
+**保守的な編集ポリシー（重要）:**
+- **無効状態を検出したら自動修復しない** - ユーザーに手動修正を要求
+- マーカーブロックが既に存在する場合は起動を拒否（二重起動防止）
+- 未完結ブロック、孤立した終了マーカー、ネストしたマーカーを検出
+- エラーメッセージで具体的な問題（行番号付き）と修正手順を提示
+- `/etc/hosts`の全内容をダンプして問題箇所を明示
+- validation型は全てpackage private（内部実装の詳細）
 
 ## 今後の拡張
 

--- a/internal/hosts/validate.go
+++ b/internal/hosts/validate.go
@@ -1,0 +1,135 @@
+package hosts
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// hostsFileState は /etc/hosts ファイルの状態を表す
+type hostsFileState struct {
+	isValid          bool     // ファイルが有効な状態か（マーカーが存在しない）
+	markerBlockCount int      // マーカーブロックの数
+	hasUnclosedBlock bool     // 開始マーカーのみで終了マーカーがない
+	hasOrphanEnd     bool     // 終了マーカーのみで開始マーカーがない
+	hasNestedMarkers bool     // ネストしたマーカー
+	problems         []string // 問題の詳細リスト（ユーザー向けメッセージ）
+	fileContent      string   // ファイル全体の内容（エラー表示用）
+}
+
+// hostsFileCorruptedError は /etc/hosts が無効状態にあることを示すエラー
+type hostsFileCorruptedError struct {
+	state *hostsFileState
+}
+
+// Error implements the error interface
+func (e *hostsFileCorruptedError) Error() string {
+	var sb strings.Builder
+	sb.WriteString("/etc/hosts is in an invalid state and cannot be automatically fixed.\n")
+	sb.WriteString("Please manually fix the following problems:\n\n")
+
+	for i, problem := range e.state.problems {
+		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, problem))
+	}
+
+	sb.WriteString("\nCurrent /etc/hosts content:\n")
+	sb.WriteString("---\n")
+	sb.WriteString(e.state.fileContent)
+	sb.WriteString("---\n")
+	sb.WriteString("\nTo fix:\n")
+	sb.WriteString("1. Manually edit /etc/hosts with sudo, like `sudo vim -u NONE /etc/hosts`\n")
+	sb.WriteString("2. Remove all lines between and including:\n")
+	sb.WriteString(fmt.Sprintf("     %s\n", markerStart))
+	sb.WriteString(fmt.Sprintf("     %s\n", markerEnd))
+	sb.WriteString("3. Run kubectl-localmesh again\n")
+
+	return sb.String()
+}
+
+// newHostsFileCorruptedError creates a new hostsFileCorruptedError
+func newHostsFileCorruptedError(state *hostsFileState) error {
+	return &hostsFileCorruptedError{state: state}
+}
+
+// validateHostsFile は /etc/hosts の状態を検証する
+func validateHostsFile() (*hostsFileState, error) {
+	state := &hostsFileState{
+		isValid:  true,
+		problems: []string{},
+	}
+
+	// ファイル読み込み
+	content, err := os.ReadFile(hostsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// ファイルが存在しない = 有効
+			return state, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", hostsFile, err)
+	}
+
+	state.fileContent = string(content)
+	lines := strings.Split(state.fileContent, "\n")
+
+	// マーカーの状態を追跡
+	inBlock := false
+	blockCount := 0
+	startLineNumber := -1
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		lineNum := i + 1 // 1-indexed for user display
+
+		switch trimmed {
+		case markerStart:
+			if inBlock {
+				// ネストした開始マーカー
+				state.hasNestedMarkers = true
+				state.problems = append(state.problems,
+					fmt.Sprintf("Nested start marker found at line %d (block started at line %d)", lineNum, startLineNumber))
+			}
+			inBlock = true
+			startLineNumber = lineNum
+			blockCount++
+		case markerEnd:
+			if !inBlock {
+				// 孤立した終了マーカー
+				state.hasOrphanEnd = true
+				state.problems = append(state.problems,
+					fmt.Sprintf("End marker without start marker found at line %d", lineNum))
+			}
+			inBlock = false
+		}
+	}
+
+	// ファイル終端で未完結
+	if inBlock {
+		state.hasUnclosedBlock = true
+		state.problems = append(state.problems,
+			fmt.Sprintf("Unclosed block: start marker at line %d has no matching end marker", startLineNumber))
+	}
+
+	state.markerBlockCount = blockCount
+
+	// マーカーブロックが存在する場合は無効（ユーザー要件）
+	if blockCount >= 1 {
+		if blockCount == 1 && !state.hasUnclosedBlock && !state.hasOrphanEnd && !state.hasNestedMarkers {
+			// 正常なブロック1つ = 前回のクリーンアップ失敗
+			state.problems = append([]string{
+				fmt.Sprintf("Existing kubectl-localmesh entries found (%d block). Clean shutdown may have failed.", blockCount),
+			}, state.problems...)
+		} else if blockCount > 1 {
+			// 複数ブロック
+			state.problems = append([]string{
+				fmt.Sprintf("Multiple marker blocks found (%d blocks). Only one is expected.", blockCount),
+			}, state.problems...)
+		}
+	}
+
+	// 有効性判定
+	if blockCount > 0 || state.hasUnclosedBlock || state.hasOrphanEnd || state.hasNestedMarkers {
+		state.isValid = false
+	}
+
+	return state, nil
+}

--- a/internal/hosts/validate_test.go
+++ b/internal/hosts/validate_test.go
@@ -1,0 +1,347 @@
+package hosts
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateHostsFile_Valid_Empty(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	// 空ファイルを作成
+	if err := os.WriteFile(testFile, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	state, err := validateHostsFile()
+	if err != nil {
+		t.Fatalf("validateHostsFile failed: %v", err)
+	}
+
+	if !state.isValid {
+		t.Errorf("expected isValid=true, got false")
+	}
+	if state.markerBlockCount != 0 {
+		t.Errorf("expected markerBlockCount=0, got %d", state.markerBlockCount)
+	}
+	if len(state.problems) != 0 {
+		t.Errorf("expected no problems, got %v", state.problems)
+	}
+}
+
+// TestValidateHostsFile_Valid_NoMarkers は、マーカーがないファイルが有効と判定されることをテストする
+func TestValidateHostsFile_Valid_NoMarkers(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	content := "127.0.0.1 localhost\n::1 localhost\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	state, err := validateHostsFile()
+	if err != nil {
+		t.Fatalf("validateHostsFile failed: %v", err)
+	}
+
+	if !state.isValid {
+		t.Errorf("expected isValid=true, got false")
+	}
+	if state.markerBlockCount != 0 {
+		t.Errorf("expected markerBlockCount=0, got %d", state.markerBlockCount)
+	}
+	if len(state.problems) != 0 {
+		t.Errorf("expected no problems, got %v", state.problems)
+	}
+}
+
+// TestValidateHostsFile_Invalid_SingleBlock は、正常なマーカーブロック1つが無効と判定されることをテストする
+func TestValidateHostsFile_Invalid_SingleBlock(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	content := "127.0.0.1 localhost\n\n" +
+		markerStart + "\n" +
+		"127.0.0.1 test.localhost\n" +
+		markerEnd + "\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	state, err := validateHostsFile()
+	if err != nil {
+		t.Fatalf("validateHostsFile failed: %v", err)
+	}
+
+	if state.isValid {
+		t.Errorf("expected isValid=false, got true")
+	}
+	if state.markerBlockCount != 1 {
+		t.Errorf("expected markerBlockCount=1, got %d", state.markerBlockCount)
+	}
+	if len(state.problems) == 0 {
+		t.Errorf("expected problems, got none")
+	}
+	// 問題メッセージに "Existing kubectl-localmesh entries found" が含まれることを確認
+	if !strings.Contains(state.problems[0], "Existing kubectl-localmesh entries found") {
+		t.Errorf("expected problem about existing entries, got %s", state.problems[0])
+	}
+}
+
+// TestValidateHostsFile_Invalid_MultipleBlocks は、複数のマーカーブロックが無効と判定されることをテストする
+func TestValidateHostsFile_Invalid_MultipleBlocks(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	content := "127.0.0.1 localhost\n\n" +
+		markerStart + "\n" +
+		"127.0.0.1 old.localhost\n" +
+		markerEnd + "\n\n" +
+		markerStart + "\n" +
+		"127.0.0.1 test.localhost\n" +
+		markerEnd + "\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	state, err := validateHostsFile()
+	if err != nil {
+		t.Fatalf("validateHostsFile failed: %v", err)
+	}
+
+	if state.isValid {
+		t.Errorf("expected isValid=false, got true")
+	}
+	if state.markerBlockCount != 2 {
+		t.Errorf("expected markerBlockCount=2, got %d", state.markerBlockCount)
+	}
+	if len(state.problems) == 0 {
+		t.Errorf("expected problems, got none")
+	}
+	// 問題メッセージに "Multiple marker blocks found" が含まれることを確認
+	if !strings.Contains(state.problems[0], "Multiple marker blocks found") {
+		t.Errorf("expected problem about multiple blocks, got %s", state.problems[0])
+	}
+}
+
+// TestValidateHostsFile_Invalid_UnclosedBlock は、開始マーカーのみが無効と判定されることをテストする
+func TestValidateHostsFile_Invalid_UnclosedBlock(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	content := "127.0.0.1 localhost\n\n" +
+		markerStart + "\n" +
+		"127.0.0.1 test.localhost\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	state, err := validateHostsFile()
+	if err != nil {
+		t.Fatalf("validateHostsFile failed: %v", err)
+	}
+
+	if state.isValid {
+		t.Errorf("expected isValid=false, got true")
+	}
+	if !state.hasUnclosedBlock {
+		t.Errorf("expected hasUnclosedBlock=true, got false")
+	}
+	if len(state.problems) == 0 {
+		t.Errorf("expected problems, got none")
+	}
+	// 問題メッセージに "Unclosed block" が含まれることを確認
+	foundUnclosedProblem := false
+	for _, p := range state.problems {
+		if strings.Contains(p, "Unclosed block") {
+			foundUnclosedProblem = true
+			break
+		}
+	}
+	if !foundUnclosedProblem {
+		t.Errorf("expected problem about unclosed block, got %v", state.problems)
+	}
+}
+
+// TestValidateHostsFile_Invalid_OrphanEnd は、終了マーカーのみが無効と判定されることをテストする
+func TestValidateHostsFile_Invalid_OrphanEnd(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	content := "127.0.0.1 localhost\n" +
+		markerEnd + "\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	state, err := validateHostsFile()
+	if err != nil {
+		t.Fatalf("validateHostsFile failed: %v", err)
+	}
+
+	if state.isValid {
+		t.Errorf("expected isValid=false, got true")
+	}
+	if !state.hasOrphanEnd {
+		t.Errorf("expected hasOrphanEnd=true, got false")
+	}
+	if len(state.problems) == 0 {
+		t.Errorf("expected problems, got none")
+	}
+	// 問題メッセージに "End marker without start marker" が含まれることを確認
+	if !strings.Contains(state.problems[0], "End marker without start marker") {
+		t.Errorf("expected problem about orphan end, got %s", state.problems[0])
+	}
+}
+
+// TestValidateHostsFile_Invalid_NestedMarkers は、ネストしたマーカーが無効と判定されることをテストする
+func TestValidateHostsFile_Invalid_NestedMarkers(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	content := markerStart + "\n" +
+		markerStart + "\n" +
+		"127.0.0.1 test.localhost\n" +
+		markerEnd + "\n" +
+		markerEnd + "\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	state, err := validateHostsFile()
+	if err != nil {
+		t.Fatalf("validateHostsFile failed: %v", err)
+	}
+
+	if state.isValid {
+		t.Errorf("expected isValid=false, got true")
+	}
+	if !state.hasNestedMarkers {
+		t.Errorf("expected hasNestedMarkers=true, got false")
+	}
+	if len(state.problems) == 0 {
+		t.Errorf("expected problems, got none")
+	}
+	// 問題メッセージに "Nested start marker" が含まれることを確認
+	foundNestedProblem := false
+	for _, p := range state.problems {
+		if strings.Contains(p, "Nested start marker") {
+			foundNestedProblem = true
+			break
+		}
+	}
+	if !foundNestedProblem {
+		t.Errorf("expected problem about nested markers, got %v", state.problems)
+	}
+}
+
+// TestValidateHostsFile_Invalid_Combined は、複合的な問題が無効と判定されることをテストする
+func TestValidateHostsFile_Invalid_Combined(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	// 複数のブロック + 未完結ブロック
+	content := markerStart + "\n" +
+		"127.0.0.1 test1.localhost\n" +
+		markerEnd + "\n" +
+		markerStart + "\n" +
+		"127.0.0.1 test2.localhost\n" // 終了マーカーがない
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	state, err := validateHostsFile()
+	if err != nil {
+		t.Fatalf("validateHostsFile failed: %v", err)
+	}
+
+	if state.isValid {
+		t.Errorf("expected isValid=false, got true")
+	}
+	if state.markerBlockCount != 2 {
+		t.Errorf("expected markerBlockCount=2, got %d", state.markerBlockCount)
+	}
+	if !state.hasUnclosedBlock {
+		t.Errorf("expected hasUnclosedBlock=true, got false")
+	}
+	// 複数の問題が報告されることを確認
+	if len(state.problems) < 2 {
+		t.Errorf("expected at least 2 problems, got %d", len(state.problems))
+	}
+}
+
+// TestAddEntries_RejectsInvalidState は、AddEntries()が無効状態を拒否することをテストする
+func TestAddEntries_RejectsInvalidState(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	// 既存のマーカーブロックを作成
+	content := "127.0.0.1 localhost\n\n" +
+		markerStart + "\n" +
+		"127.0.0.1 old.localhost\n" +
+		markerEnd + "\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	hostnames := []string{"new.localhost"}
+
+	// AddEntries()はエラーを返すべき
+	err := AddEntries(hostnames)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	// エラーが hostsFileCorruptedError であることを確認
+	var corruptedErr *hostsFileCorruptedError
+	if !errors.As(err, &corruptedErr) {
+		t.Errorf("expected hostsFileCorruptedError, got %T", err)
+	}
+}
+
+// TestHostsFileCorruptedError_Message は、hostsFileCorruptedErrorのエラーメッセージをテストする
+func TestHostsFileCorruptedError_Message(t *testing.T) {
+	state := &hostsFileState{
+		isValid:          false,
+		markerBlockCount: 1,
+		problems: []string{
+			"Existing kubectl-localmesh entries found (1 block). Clean shutdown may have failed.",
+		},
+		fileContent: "127.0.0.1 localhost\n\n" +
+			markerStart + "\n" +
+			"127.0.0.1 test.localhost\n" +
+			markerEnd + "\n",
+	}
+
+	err := newHostsFileCorruptedError(state)
+	errMsg := err.Error()
+
+	// エラーメッセージに必要な情報が含まれることを確認
+	requiredStrings := []string{
+		"/etc/hosts is in an invalid state",
+		"Existing kubectl-localmesh entries found",
+		"Current /etc/hosts content:",
+		"To fix:",
+		markerStart,
+		markerEnd,
+	}
+
+	for _, required := range requiredStrings {
+		if !strings.Contains(errMsg, required) {
+			t.Errorf("error message missing required string %q", required)
+		}
+	}
+}


### PR DESCRIPTION
close #39 

Implement validation to detect invalid /etc/hosts state and prevent
automatic corruption fixes. The tool now requires manual user intervention
when issues are detected.

Features:
- Detect invalid states (existing blocks, unclosed blocks, orphan markers, nested markers)
- Show detailed error messages with line numbers and full file dump
- Reject startup if marker blocks already exist (prevents double startup)
- Split validation code into separate file (validate.go) with package-private types
- Remove redundant RemoveEntries() call from AddEntries()

Implementation follows TDD:
- Added comprehensive test cases covering all invalid states
- Achieved 82.8% test coverage in hosts package
- All tests pass, 0 lint issues

Technical details:
- validation types are package-private: hostsFileState, hostsFileCorruptedError
- Uses switch statement for marker detection (staticcheck compliant)
- Conservative policy: never auto-fix, always ask user to manually edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>