### PR TITLE
refactor: reorganize CLI options and introduce dump-envoy-config subcommand

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,8 +30,9 @@ Kubernetesサービス
 
 1. **cmd** (`cmd/`)
    - Cobraベースのサブコマンド実装
-   - `root.go`: ルートコマンド定義
+   - `root.go`: ルートコマンド定義（グローバルフラグ: `--log-level`）
    - `up.go`: サービスメッシュ起動（upサブコマンド）
+   - `dump_envoy_config.go`: Envoy設定のダンプ（dump-envoy-configサブコマンド）
    - (将来) `down.go`: サービスメッシュ停止
    - (将来) `status.go`: ステータス表示
 
@@ -93,9 +94,9 @@ Taskfileを使った標準開発ワークフローを提供します。
 Envoy設定の確認とデバッグを支援します。
 
 **主な機能**:
-- `--dump-envoy-config`: Envoy設定のダンプ
-- `--mock-config`: オフラインモード（クラスタ接続不要）
-- `-log debug`: 詳細デバッグログ
+- `dump-envoy-config`: Envoy設定のダンプ（サブコマンド）
+- `--mock-config`: オフラインモード（クラスタ接続不要、dump-envoy-configのオプション）
+- `--log-level debug`: 詳細デバッグログ（グローバルフラグ）
 - Envoy設定の検証とトラブルシューティング
 
 詳細: `.claude/skills/kubectl-envoy-debugging/SKILL.md`
@@ -221,10 +222,10 @@ done
 ```
 
 **基本動作:**
-- `--update-hosts`フラグのデフォルトは`true`
+- デフォルトでは/etc/hostsを自動的に更新（`--no-edit-hosts`でスキップ可能）
 - 通常起動時は自動的に/etc/hostsを更新（sudo必要）
 - 終了時（Ctrl+C）に自動クリーンアップ
-- `--dump-envoy-config`モードでは更新しない
+- `dump-envoy-config`サブコマンドでは更新しない
 - 一時ファイル経由で安全に書き換え
 
 **保守的な編集ポリシー（重要）:**
@@ -239,7 +240,7 @@ done
 
 READMEに記載されているロードマップ:
 - krew配布
-- ✅ サブコマンド（`up`実装済み、`down`と`status`は計画中）
+- ✅ サブコマンド（`up`と`dump-envoy-config`実装済み、`down`と`status`は計画中）
 - TLS対応（ローカル証明書）
 - gRPC-web対応
 - Envoy不要のHTTP専用モード

--- a/README.md
+++ b/README.md
@@ -142,14 +142,29 @@ sudo kubectl localmesh up services.yaml
 To disable automatic `/etc/hosts` update:
 
 ```bash
-kubectl localmesh up -f services.yaml --update-hosts=false
+kubectl localmesh up -f services.yaml --no-edit-hosts
 ```
 
 ### Subcommands
 
 - `up`: Start the local service mesh
+- `dump-envoy-config`: Dump Envoy configuration to stdout
 - `down`: Stop the running mesh (planned)
 - `status`: Show mesh status (planned)
+
+### Global Flags
+
+The following flags are available for all subcommands:
+
+- `--log-level string`: Log level for Envoy and internal operations (debug|info|warn, default: info)
+
+Examples:
+
+```bash
+# Debug mode for all subcommands
+kubectl localmesh --log-level debug up -f services.yaml
+kubectl localmesh --log-level debug dump-envoy-config -f services.yaml
+```
 
 Example output:
 
@@ -203,7 +218,7 @@ This automatically adds entries like:
 **Disable automatic /etc/hosts update:**
 
 ```bash
-kubectl localmesh up -f services.yaml --update-hosts=false
+kubectl localmesh up -f services.yaml --no-edit-hosts
 
 # In this case, you need to specify the Host header manually:
 curl -H "Host: users-api.localhost" http://127.0.0.1:80/
@@ -220,7 +235,7 @@ When you stop kubectl-localmesh (Ctrl+C), it automatically removes the managed e
 You can dump the generated Envoy configuration to stdout for debugging or inspection:
 
 ```bash
-kubectl localmesh up -f services.yaml --dump-envoy-config
+kubectl localmesh dump-envoy-config -f services.yaml
 ```
 
 This is useful for:
@@ -251,7 +266,7 @@ mocks:
 EOF
 
 # Dump config using mocks (no cluster connection required)
-kubectl localmesh up -f services.yaml --dump-envoy-config --mock-config mocks.yaml
+kubectl localmesh dump-envoy-config -f services.yaml --mock-config mocks.yaml
 ```
 
 This is useful for:

--- a/cmd/dump_envoy_config.go
+++ b/cmd/dump_envoy_config.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/usadamasa/kubectl-localmesh/internal/config"
+	"github.com/usadamasa/kubectl-localmesh/internal/run"
+)
+
+type dumpEnvoyConfigOptions struct {
+	configFile string
+	mockConfig string
+}
+
+var dumpEnvoyConfigOpts = &dumpEnvoyConfigOptions{}
+
+var dumpEnvoyConfigCmd = &cobra.Command{
+	Use:   "dump-envoy-config [config-file]",
+	Short: "Envoy設定をstdoutにダンプ",
+	Long: `サービスを起動せずにEnvoy設定を生成してstdoutにダンプします。
+
+以下の用途に有用です：
+- 生成されるEnvoy設定の理解
+- ルーティングの問題のデバッグ
+- Envoy設定パターンの学習
+- --mock-configによるオフライン設定検証
+
+Examples:
+  kubectl-localmesh dump-envoy-config -f services.yaml
+  kubectl-localmesh dump-envoy-config services.yaml
+  kubectl-localmesh dump-envoy-config -f services.yaml --mock-config mocks.yaml`,
+	RunE: runDumpEnvoyConfig,
+}
+
+func init() {
+	rootCmd.AddCommand(dumpEnvoyConfigCmd)
+
+	dumpEnvoyConfigCmd.Flags().StringVarP(
+		&dumpEnvoyConfigOpts.configFile,
+		"config", "f", "",
+		"設定ファイルのパス",
+	)
+	dumpEnvoyConfigCmd.Flags().StringVar(
+		&dumpEnvoyConfigOpts.mockConfig,
+		"mock-config", "",
+		"オフラインモード用のモック設定（クラスタ接続不要）",
+	)
+}
+
+func runDumpEnvoyConfig(cmd *cobra.Command, args []string) error {
+	if dumpEnvoyConfigOpts.configFile == "" && len(args) > 0 {
+		dumpEnvoyConfigOpts.configFile = args[0]
+	}
+
+	if dumpEnvoyConfigOpts.configFile == "" {
+		return fmt.Errorf("config file required: use -f or provide as argument")
+	}
+
+	cfg, err := config.Load(dumpEnvoyConfigOpts.configFile)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	ctx := cmd.Context()
+
+	return run.DumpEnvoyConfig(ctx, cfg, dumpEnvoyConfigOpts.mockConfig)
+}

--- a/cmd/dump_envoy_config_test.go
+++ b/cmd/dump_envoy_config_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestDumpEnvoyConfigCommand_FlagParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantConfig  string
+		wantMock    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:       "flag形式で設定ファイル指定",
+			args:       []string{"-f", "testdata/test-services.yaml"},
+			wantConfig: "testdata/test-services.yaml",
+			wantMock:   "",
+			wantErr:    false,
+		},
+		{
+			name:       "long flag形式で設定ファイル指定",
+			args:       []string{"--config", "testdata/test-services.yaml"},
+			wantConfig: "testdata/test-services.yaml",
+			wantMock:   "",
+			wantErr:    false,
+		},
+		{
+			name:       "位置引数で設定ファイル指定",
+			args:       []string{"testdata/test-services.yaml"},
+			wantConfig: "testdata/test-services.yaml",
+			wantMock:   "",
+			wantErr:    false,
+		},
+		{
+			name:       "mock-config指定",
+			args:       []string{"-f", "testdata/test-services.yaml", "--mock-config", "testdata/mocks.yaml"},
+			wantConfig: "testdata/test-services.yaml",
+			wantMock:   "testdata/mocks.yaml",
+			wantErr:    false,
+		},
+		{
+			name:        "設定ファイル未指定",
+			args:        []string{},
+			wantErr:     true,
+			errContains: "config file required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dumpEnvoyConfigOpts = &dumpEnvoyConfigOptions{}
+
+			cmd := &cobra.Command{
+				Use: "test",
+				RunE: func(cmd *cobra.Command, args []string) error {
+					if dumpEnvoyConfigOpts.configFile == "" && len(args) > 0 {
+						dumpEnvoyConfigOpts.configFile = args[0]
+					}
+					if dumpEnvoyConfigOpts.configFile == "" {
+						return fmt.Errorf("config file required")
+					}
+					return nil
+				},
+			}
+
+			cmd.Flags().StringVarP(&dumpEnvoyConfigOpts.configFile, "config", "f", "", "config yaml path")
+			cmd.Flags().StringVar(&dumpEnvoyConfigOpts.mockConfig, "mock-config", "", "mock config path")
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil {
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Error message should contain %q, got %q", tt.errContains, err.Error())
+				}
+			}
+
+			if !tt.wantErr {
+				if dumpEnvoyConfigOpts.configFile != tt.wantConfig {
+					t.Errorf("configFile = %v, want %v", dumpEnvoyConfigOpts.configFile, tt.wantConfig)
+				}
+				if dumpEnvoyConfigOpts.mockConfig != tt.wantMock {
+					t.Errorf("mockConfig = %v, want %v", dumpEnvoyConfigOpts.mockConfig, tt.wantMock)
+				}
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var globalLogLevel string
+
 var rootCmd = &cobra.Command{
 	Use:   "kubectl-localmesh",
 	Short: "Local-only pseudo service mesh built on kubectl port-forward",
@@ -13,6 +15,15 @@ for local development without installing anything into your cluster.
 Built on kubectl port-forward, it runs a local Envoy proxy for host-based routing.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(
+		&globalLogLevel,
+		"log-level",
+		"info",
+		"log level: debug|info|warn",
+	)
 }
 
 func Execute() error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestRootCommand(t *testing.T) {
@@ -11,4 +13,47 @@ func TestRootCommand(t *testing.T) {
 			t.Errorf("Execute() returned error: %v", err)
 		}
 	})
+}
+
+func TestRootCommand_GlobalFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantLogLevel string
+	}{
+		{
+			name:         "デフォルトログレベル",
+			args:         []string{},
+			wantLogLevel: "info",
+		},
+		{
+			name:         "グローバルフラグでdebug指定",
+			args:         []string{"--log-level", "debug"},
+			wantLogLevel: "debug",
+		},
+		{
+			name:         "グローバルフラグでwarn指定",
+			args:         []string{"--log-level", "warn"},
+			wantLogLevel: "warn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			globalLogLevel = "info"
+
+			cmd := &cobra.Command{Use: "test"}
+			cmd.PersistentFlags().StringVar(&globalLogLevel, "log-level", "info", "log level")
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if err != nil {
+				t.Errorf("Execute() error = %v", err)
+			}
+
+			if globalLogLevel != tt.wantLogLevel {
+				t.Errorf("globalLogLevel = %v, want %v", globalLogLevel, tt.wantLogLevel)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Changes

### Command Structure
- Move `--log-level` to global flag (available for all subcommands)
- Extract `dump-envoy-config` as independent subcommand
- Rename `--update-hosts` to `--no-edit-hosts` with inverted logic

### New Subcommand: dump-envoy-config
- Create `cmd/dump_envoy_config.go` with dedicated subcommand
- Move `--mock-config` option from `up` to `dump-envoy-config`
- Support both flag and positional argument for config file

### Updated `up` Subcommand
- Remove `--log-level` (now global flag)
- Remove `--dump-envoy-config` (now separate subcommand)
- Remove `--mock-config` (moved to dump-envoy-config)
- Replace `--update-hosts` with `--no-edit-hosts` (default: false = edit hosts)

### Tests
- Add `cmd/dump_envoy_config_test.go` for new subcommand
- Add `TestRootCommand_GlobalFlags` for global flag testing
- Remove `TestUpCommand_DumpEnvoyConfig` (moved to separate subcommand)
- Remove `TestUpCommand_LogLevel` (now tests global flag)
- Rename `TestUpCommand_UpdateHosts` to `TestUpCommand_NoEditHosts`

### Documentation
- Update README.md with new command structure and examples
- Update .claude/CLAUDE.md to reflect architectural changes
- Add Global Flags section to README

## Breaking Changes
- `kubectl-localmesh up --dump-envoy-config` → `kubectl-localmesh dump-envoy-config`
- `kubectl-localmesh up --update-hosts=false` → `kubectl-localmesh up --no-edit-hosts`
- `kubectl-localmesh up --log-level debug` → `kubectl-localmesh --log-level debug up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)