### PR TITLE
bugfix: suport http1

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,8 +151,8 @@ func (k *KubernetesService) Validate(cfg *Config) error {
 	if k.Service == "" {
 		return fmt.Errorf("service is required for kubernetes service '%s'", k.Host)
 	}
-	if k.Protocol != "http" && k.Protocol != "grpc" {
-		return fmt.Errorf("protocol must be 'http' or 'grpc' for kubernetes service '%s', got '%s'", k.Host, k.Protocol)
+	if k.Protocol != "http" && k.Protocol != "http2" && k.Protocol != "grpc" {
+		return fmt.Errorf("protocol must be 'http', 'http2', or 'grpc' for kubernetes service '%s', got '%s'", k.Host, k.Protocol)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -894,7 +894,7 @@ func TestKubernetesService_ValidateEdgeCases(t *testing.T) {
 			name:    "invalid protocol",
 			svc:     &KubernetesService{Host: "test.localhost", Namespace: "test", Service: "svc", Protocol: "invalid"},
 			wantErr: true,
-			errMsg:  "protocol must be",
+			errMsg:  "protocol must be 'http', 'http2', or 'grpc'",
 		},
 	}
 

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -12,6 +12,7 @@ func TestBuildConfig_HTTPOnly(t *testing.T) {
 			LocalPort:   10001,
 			ClusterName: "api_cluster",
 			Type:        "http",
+			Protocol:    "http",
 		},
 	}
 
@@ -100,6 +101,7 @@ func TestBuildConfig_MixedHTTPAndTCP(t *testing.T) {
 			LocalPort:   10001,
 			ClusterName: "api_cluster",
 			Type:        "http",
+			Protocol:    "http",
 		},
 		{
 			Host:        "db.localhost",
@@ -179,5 +181,231 @@ func TestBuildConfig_MultipleTCPSamePort(t *testing.T) {
 	// 2つのリスナーが作成される（ポート重複は警告すべきだが、現時点では許容）
 	if len(listeners) != 2 {
 		t.Errorf("expected 2 listeners, got %d", len(listeners))
+	}
+}
+
+func TestBuildConfig_HTTPProtocol(t *testing.T) {
+	// protocol: http → HTTP/1.1設定確認
+	routes := []Route{
+		{
+			Host:        "api.localhost",
+			LocalPort:   10001,
+			ClusterName: "api_cluster",
+			Type:        "http",
+			Protocol:    "http",
+		},
+	}
+
+	cfg := BuildConfig(80, routes)
+
+	staticRes, ok := cfg["static_resources"].(map[string]any)
+	if !ok {
+		t.Fatal("static_resources not found")
+	}
+
+	clusters, ok := staticRes["clusters"].([]any)
+	if !ok {
+		t.Fatal("clusters not found")
+	}
+
+	if len(clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d", len(clusters))
+	}
+
+	cluster := clusters[0].(map[string]any)
+	protocolOpts, ok := cluster["typed_extension_protocol_options"].(map[string]any)
+	if !ok {
+		t.Fatal("typed_extension_protocol_options not found")
+	}
+
+	httpOpts, ok := protocolOpts["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"].(map[string]any)
+	if !ok {
+		t.Fatal("HttpProtocolOptions not found")
+	}
+
+	explicitConfig, ok := httpOpts["explicit_http_config"].(map[string]any)
+	if !ok {
+		t.Fatal("explicit_http_config not found")
+	}
+
+	// HTTP/1.1の設定を確認
+	if _, ok := explicitConfig["http_protocol_options"]; !ok {
+		t.Error("expected http1_protocol_options for protocol: http")
+	}
+
+	// HTTP/2の設定がないことを確認
+	if _, ok := explicitConfig["http2_protocol_options"]; ok {
+		t.Error("unexpected http2_protocol_options for protocol: http")
+	}
+}
+
+func TestBuildConfig_HTTP2Protocol(t *testing.T) {
+	// protocol: http2 → HTTP/2設定確認
+	routes := []Route{
+		{
+			Host:        "api.localhost",
+			LocalPort:   10001,
+			ClusterName: "api_cluster",
+			Type:        "http",
+			Protocol:    "http2",
+		},
+	}
+
+	cfg := BuildConfig(80, routes)
+
+	staticRes, ok := cfg["static_resources"].(map[string]any)
+	if !ok {
+		t.Fatal("static_resources not found")
+	}
+
+	clusters, ok := staticRes["clusters"].([]any)
+	if !ok {
+		t.Fatal("clusters not found")
+	}
+
+	if len(clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d", len(clusters))
+	}
+
+	cluster := clusters[0].(map[string]any)
+	protocolOpts, ok := cluster["typed_extension_protocol_options"].(map[string]any)
+	if !ok {
+		t.Fatal("typed_extension_protocol_options not found")
+	}
+
+	httpOpts, ok := protocolOpts["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"].(map[string]any)
+	if !ok {
+		t.Fatal("HttpProtocolOptions not found")
+	}
+
+	explicitConfig, ok := httpOpts["explicit_http_config"].(map[string]any)
+	if !ok {
+		t.Fatal("explicit_http_config not found")
+	}
+
+	// HTTP/2の設定を確認
+	if _, ok := explicitConfig["http2_protocol_options"]; !ok {
+		t.Error("expected http2_protocol_options for protocol: http2")
+	}
+
+	// HTTP/1.1の設定がないことを確認
+	if _, ok := explicitConfig["http_protocol_options"]; ok {
+		t.Error("unexpected http1_protocol_options for protocol: http2")
+	}
+}
+
+func TestBuildConfig_gRPCProtocol(t *testing.T) {
+	// protocol: grpc → HTTP/2設定確認
+	routes := []Route{
+		{
+			Host:        "grpc.localhost",
+			LocalPort:   10001,
+			ClusterName: "grpc_cluster",
+			Type:        "http",
+			Protocol:    "grpc",
+		},
+	}
+
+	cfg := BuildConfig(80, routes)
+
+	staticRes, ok := cfg["static_resources"].(map[string]any)
+	if !ok {
+		t.Fatal("static_resources not found")
+	}
+
+	clusters, ok := staticRes["clusters"].([]any)
+	if !ok {
+		t.Fatal("clusters not found")
+	}
+
+	if len(clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d", len(clusters))
+	}
+
+	cluster := clusters[0].(map[string]any)
+	protocolOpts, ok := cluster["typed_extension_protocol_options"].(map[string]any)
+	if !ok {
+		t.Fatal("typed_extension_protocol_options not found")
+	}
+
+	httpOpts, ok := protocolOpts["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"].(map[string]any)
+	if !ok {
+		t.Fatal("HttpProtocolOptions not found")
+	}
+
+	explicitConfig, ok := httpOpts["explicit_http_config"].(map[string]any)
+	if !ok {
+		t.Fatal("explicit_http_config not found")
+	}
+
+	// HTTP/2の設定を確認（gRPCはHTTP/2必須）
+	if _, ok := explicitConfig["http2_protocol_options"]; !ok {
+		t.Error("expected http2_protocol_options for protocol: grpc")
+	}
+
+	// HTTP/1.1の設定がないことを確認
+	if _, ok := explicitConfig["http_protocol_options"]; ok {
+		t.Error("unexpected http1_protocol_options for protocol: grpc")
+	}
+}
+
+func TestBuildConfig_MixedProtocols(t *testing.T) {
+	// http/http2/grpcの共存確認
+	routes := []Route{
+		{
+			Host:        "api.localhost",
+			LocalPort:   10001,
+			ClusterName: "api_cluster",
+			Type:        "http",
+			Protocol:    "http", // HTTP/1.1
+		},
+		{
+			Host:        "api2.localhost",
+			LocalPort:   10002,
+			ClusterName: "api2_cluster",
+			Type:        "http",
+			Protocol:    "http2", // HTTP/2
+		},
+		{
+			Host:        "grpc.localhost",
+			LocalPort:   10003,
+			ClusterName: "grpc_cluster",
+			Type:        "http",
+			Protocol:    "grpc", // gRPC (HTTP/2)
+		},
+	}
+
+	cfg := BuildConfig(80, routes)
+
+	staticRes, ok := cfg["static_resources"].(map[string]any)
+	if !ok {
+		t.Fatal("static_resources not found")
+	}
+
+	clusters, ok := staticRes["clusters"].([]any)
+	if !ok {
+		t.Fatal("clusters not found")
+	}
+
+	if len(clusters) != 3 {
+		t.Fatalf("expected 3 clusters, got %d", len(clusters))
+	}
+
+	// 各クラスタのプロトコル設定を確認
+	for i, expectedProtocol := range []string{"http1", "http2", "http2"} {
+		cluster := clusters[i].(map[string]any)
+		protocolOpts := cluster["typed_extension_protocol_options"].(map[string]any)
+		httpOpts := protocolOpts["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"].(map[string]any)
+		explicitConfig := httpOpts["explicit_http_config"].(map[string]any)
+
+		if expectedProtocol == "http1" {
+			if _, ok := explicitConfig["http_protocol_options"]; !ok {
+				t.Errorf("cluster %d: expected http1_protocol_options", i)
+			}
+		} else {
+			if _, ok := explicitConfig["http2_protocol_options"]; !ok {
+				t.Errorf("cluster %d: expected http2_protocol_options", i)
+			}
+		}
 	}
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -68,6 +68,7 @@ func Run(ctx context.Context, cfg *config.Config, logLevel string, updateHosts b
 		var localPort int
 		var clusterName string
 		var routeType string
+		var routeProtocol string
 		var listenPort int
 
 		// type switchで型判別
@@ -138,9 +139,10 @@ func Run(ctx context.Context, cfg *config.Config, logLevel string, updateHosts b
 			localPort = lp
 
 			clusterName = sanitize(fmt.Sprintf("%s_%s_%d", s.Namespace, s.Service, remotePort))
-			routeType = s.Protocol
-			if routeType == "" {
-				routeType = "http" // デフォルト
+			routeType = "http" // 非TCPサービスは "http" に統一
+			routeProtocol = s.Protocol
+			if routeProtocol == "" {
+				routeProtocol = "http" // デフォルトはHTTP/1.1
 			}
 
 			fmt.Printf(
@@ -180,6 +182,7 @@ func Run(ctx context.Context, cfg *config.Config, logLevel string, updateHosts b
 			LocalPort:   localPort,
 			ClusterName: clusterName,
 			Type:        routeType,
+			Protocol:    routeProtocol,
 			ListenPort:  listenPort,
 		})
 	}
@@ -275,7 +278,8 @@ func DumpEnvoyConfig(ctx context.Context, cfg *config.Config, mockConfigPath str
 				Host:        s.Host,
 				LocalPort:   dummyLocalPort,
 				ClusterName: clusterName,
-				Type:        s.Protocol,
+				Type:        "http",
+				Protocol:    s.Protocol,
 			})
 
 		case *config.TCPService:


### PR DESCRIPTION
無条件にhttp2を前提としていたが、明示的にhttp1を指定できるようにする。