### PR TITLE
fix: Envoy domainsにhost:port形式を追加してgRPCクライアント互換性を改善

### DIFF
--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -22,7 +22,7 @@ func BuildConfig(listenerPort port.ListenerPort, configs []ServiceConfig) map[st
 		// type switchで各ビルダーを処理
 		switch builder := cfg.Builder.(type) {
 		case *KubernetesServiceBuilder:
-			result := builder.Build(cfg.ClusterName, cfg.LocalPort)
+			result := builder.Build(cfg.ClusterName, cfg.LocalPort, int(listenerPort))
 			// 戻り値の型によって処理を分岐
 			switch components := result.(type) {
 			case HTTPComponents:

--- a/internal/envoy/kubernetes_test.go
+++ b/internal/envoy/kubernetes_test.go
@@ -14,7 +14,7 @@ func TestKubernetesServiceBuilder_Build_HTTPRoute(t *testing.T) {
 		nil, // OverwriteListenPorts
 	)
 
-	result := builder.Build("api_cluster", 10001)
+	result := builder.Build("api_cluster", 10001, 80)
 
 	// HTTPComponentsを返すことを確認
 	httpComponents, ok := result.(HTTPComponents)
@@ -41,7 +41,7 @@ func TestKubernetesServiceBuilder_Build_WithOverwriteListenPorts(t *testing.T) {
 		[]port.IndividualListenerPort{50051, 50052},
 	)
 
-	result := builder.Build("grpc_cluster", 10001)
+	result := builder.Build("grpc_cluster", 10001, 80)
 
 	// IndividualListenerComponentsを返すことを確認
 	listenerComponents, ok := result.(IndividualListenerComponents)
@@ -79,7 +79,7 @@ func TestKubernetesServiceBuilder_Build_SingleListenPort(t *testing.T) {
 		[]port.IndividualListenerPort{50051},
 	)
 
-	result := builder.Build("grpc_cluster", 10001)
+	result := builder.Build("grpc_cluster", 10001, 80)
 
 	listenerComponents, ok := result.(IndividualListenerComponents)
 	if !ok {
@@ -109,7 +109,7 @@ func TestKubernetesServiceBuilder_Build_HTTP_WithOverwriteListenPorts(t *testing
 		[]port.IndividualListenerPort{8080},
 	)
 
-	result := builder.Build("http_cluster", 10001)
+	result := builder.Build("http_cluster", 10001, 80)
 
 	listenerComponents, ok := result.(IndividualListenerComponents)
 	if !ok {
@@ -139,7 +139,7 @@ func TestKubernetesServiceBuilder_Build_gRPC_WithOverwriteListenPorts(t *testing
 		[]port.IndividualListenerPort{50051},
 	)
 
-	result := builder.Build("grpc_cluster", 10001)
+	result := builder.Build("grpc_cluster", 10001, 80)
 
 	listenerComponents, ok := result.(IndividualListenerComponents)
 	if !ok {

--- a/testdata/envoy-snapshots/testdata/snapshots/grpc-with-listen-ports.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/grpc-with-listen-ports.yaml
@@ -49,7 +49,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - grpc.localhost
-                                - '*'
+                                - grpc.localhost:50051
                               name: default_grpc_svc_50051
                               routes:
                                 - match:

--- a/testdata/envoy-snapshots/testdata/snapshots/http-only.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/http-only.yaml
@@ -49,6 +49,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - api.localhost
+                                - api.localhost:80
                               name: default_api_8080
                               routes:
                                 - match:

--- a/testdata/envoy-snapshots/testdata/snapshots/mixed-http-tcp.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/mixed-http-tcp.yaml
@@ -73,6 +73,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - api.localhost
+                                - api.localhost:80
                               name: default_api_8080
                               routes:
                                 - match:

--- a/testdata/envoy-snapshots/testdata/snapshots/mixed-protocols.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/mixed-protocols.yaml
@@ -83,6 +83,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - api.localhost
+                                - api.localhost:80
                               name: default_api_8080
                               routes:
                                 - match:
@@ -92,6 +93,7 @@ static_resources:
                                     timeout: 0s
                             - domains:
                                 - api2.localhost
+                                - api2.localhost:80
                               name: default_api2_8080
                               routes:
                                 - match:
@@ -101,6 +103,7 @@ static_resources:
                                     timeout: 0s
                             - domains:
                                 - grpc.localhost
+                                - grpc.localhost:80
                               name: default_grpc_service_9090
                               routes:
                                 - match:

--- a/testdata/envoy-snapshots/testdata/snapshots/multiple-grpc-listen-ports.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/multiple-grpc-listen-ports.yaml
@@ -100,6 +100,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - legacy-grpc.localhost
+                                - legacy-grpc.localhost:80
                               name: default_legacy_grpc_svc_9090
                               routes:
                                 - match:
@@ -109,6 +110,7 @@ static_resources:
                                     timeout: 0s
                             - domains:
                                 - http.localhost
+                                - http.localhost:80
                               name: default_http_svc_8080
                               routes:
                                 - match:
@@ -140,7 +142,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - grpc1.localhost
-                                - '*'
+                                - grpc1.localhost:50051
                               name: default_grpc1_svc_50051
                               routes:
                                 - match:
@@ -172,7 +174,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - grpc1.localhost
-                                - '*'
+                                - grpc1.localhost:50052
                               name: default_grpc1_svc_50051
                               routes:
                                 - match:
@@ -204,7 +206,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - grpc2.localhost
-                                - '*'
+                                - grpc2.localhost:51051
                               name: default_grpc2_svc_51051
                               routes:
                                 - match:

--- a/testdata/envoy-snapshots/testdata/snapshots/protocol-grpc.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/protocol-grpc.yaml
@@ -49,6 +49,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - grpc.localhost
+                                - grpc.localhost:80
                               name: default_grpc_service_9090
                               routes:
                                 - match:

--- a/testdata/envoy-snapshots/testdata/snapshots/protocol-http.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/protocol-http.yaml
@@ -49,6 +49,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - api.localhost
+                                - api.localhost:80
                               name: default_api_8080
                               routes:
                                 - match:

--- a/testdata/envoy-snapshots/testdata/snapshots/protocol-http2.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/protocol-http2.yaml
@@ -49,6 +49,7 @@ static_resources:
                         virtual_hosts:
                             - domains:
                                 - api.localhost
+                                - api.localhost:80
                               name: default_api_8080
                               routes:
                                 - match:


### PR DESCRIPTION
gRPCクライアント（grpcurl等）は:authorityヘッダーにhost:port形式で送信するため、 Envoyのdomains設定にhost単体とhost:port両方のパターンを含めるよう修正。
これによりgRPC reflectionが正しく動作するようになる。