### PR TITLE
refactor: Portをジェネリック型制約に変更しキャスト削減

### DIFF
--- a/internal/envoy/config.go
+++ b/internal/envoy/config.go
@@ -6,8 +6,8 @@ import "github.com/usadamasa/kubectl-localmesh/internal/port"
 type ServiceConfig struct {
 	Builder            interface{} // *KubernetesServiceBuilder または *TCPServiceBuilder
 	ClusterName        string
-	LocalPort          int
-	ResolvedRemotePort int // Kubernetesサービスの解決済みリモートポート（マッピング出力用）
+	LocalPort          port.LocalPort
+	ResolvedRemotePort port.ServicePort // Kubernetesサービスの解決済みリモートポート（マッピング出力用）
 }
 
 // BuildConfig は ServiceConfig のリストから Envoy 設定を生成
@@ -22,7 +22,7 @@ func BuildConfig(listenerPort port.ListenerPort, configs []ServiceConfig) map[st
 		// type switchで各ビルダーを処理
 		switch builder := cfg.Builder.(type) {
 		case *KubernetesServiceBuilder:
-			result := builder.Build(cfg.ClusterName, cfg.LocalPort, int(listenerPort))
+			result := builder.Build(cfg.ClusterName, int(cfg.LocalPort), int(listenerPort))
 			// 戻り値の型によって処理を分岐
 			switch components := result.(type) {
 			case HTTPComponents:
@@ -36,7 +36,7 @@ func BuildConfig(listenerPort port.ListenerPort, configs []ServiceConfig) map[st
 			}
 
 		case *TCPServiceBuilder:
-			components := builder.Build(cfg.ClusterName, cfg.LocalPort)
+			components := builder.Build(cfg.ClusterName, int(cfg.LocalPort))
 			clusters = append(clusters, components.Cluster)
 			tcpListeners = append(tcpListeners, components.Listener)
 		}

--- a/internal/gcp/ssh_tunnel_test.go
+++ b/internal/gcp/ssh_tunnel_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/usadamasa/kubectl-localmesh/internal/config"
 	"github.com/usadamasa/kubectl-localmesh/internal/log"
+	"github.com/usadamasa/kubectl-localmesh/internal/port"
 )
 
 func TestStartGCPSSHTunnel_BasicFlow(t *testing.T) {
@@ -21,9 +22,9 @@ func TestStartGCPSSHTunnel_BasicFlow(t *testing.T) {
 		Project:  "test-project",
 	}
 
-	localPort := 10000
+	localPort := port.LocalPort(10000)
 	targetHost := "10.0.0.1"
-	targetPort := 5432
+	targetPort := port.TCPPort(5432)
 
 	// テスト用のモックを使用する予定
 	// 現時点では実装がないため、関数が存在することだけを確認
@@ -99,9 +100,9 @@ func TestBuildGcloudSSHCommand(t *testing.T) {
 	tests := []struct {
 		name       string
 		bastion    *config.SSHBastion
-		localPort  int
+		localPort  port.LocalPort
 		targetHost string
-		targetPort int
+		targetPort port.TCPPort
 		want       []string
 	}{
 		{

--- a/internal/k8s/service.go
+++ b/internal/k8s/service.go
@@ -7,6 +7,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/usadamasa/kubectl-localmesh/internal/port"
 )
 
 // ResolveServicePort resolves the service port based on the provided parameters.
@@ -18,11 +20,11 @@ func ResolveServicePort(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	namespace, serviceName, portName string,
-	port int,
-) (int, error) {
+	p port.ServicePort,
+) (port.ServicePort, error) {
 	// 明示的なport指定があればそれを返す
-	if port != 0 {
-		return port, nil
+	if p != 0 {
+		return p, nil
 	}
 
 	// Serviceを取得
@@ -42,9 +44,9 @@ func ResolveServicePort(
 
 	// portName指定がある場合: svc.Spec.Portsから該当するポートを検索
 	if strings.TrimSpace(portName) != "" {
-		for _, p := range svc.Spec.Ports {
-			if p.Name == portName {
-				return int(p.Port), nil
+		for _, servicePort := range svc.Spec.Ports {
+			if servicePort.Name == portName {
+				return port.ServicePort(servicePort.Port), nil
 			}
 		}
 		// 該当するポートが見つからない場合
@@ -52,5 +54,5 @@ func ResolveServicePort(
 	}
 
 	// portName指定がない場合: svc.Spec.Ports[0]を返す
-	return int(svc.Spec.Ports[0].Port), nil
+	return port.ServicePort(svc.Spec.Ports[0].Port), nil
 }

--- a/internal/k8s/service_test.go
+++ b/internal/k8s/service_test.go
@@ -7,6 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/usadamasa/kubectl-localmesh/internal/port"
 )
 
 func TestResolveServicePort(t *testing.T) {
@@ -15,9 +17,9 @@ func TestResolveServicePort(t *testing.T) {
 		namespace     string
 		serviceName   string
 		portName      string
-		port          int
+		port          port.ServicePort
 		service       *corev1.Service
-		expectedPort  int
+		expectedPort  port.ServicePort
 		expectedError string
 	}{
 		{
@@ -181,7 +183,7 @@ func TestResolveServicePort(t *testing.T) {
 				}
 			}
 
-			port, err := ResolveServicePort(
+			p, err := ResolveServicePort(
 				ctx,
 				clientset,
 				tt.namespace,
@@ -202,8 +204,8 @@ func TestResolveServicePort(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
-				if port != tt.expectedPort {
-					t.Errorf("expected port %d, got %d", tt.expectedPort, port)
+				if p != tt.expectedPort {
+					t.Errorf("expected port %d, got %d", tt.expectedPort, p)
 				}
 			}
 		})

--- a/internal/log/summary.go
+++ b/internal/log/summary.go
@@ -3,6 +3,8 @@ package log
 import (
 	"fmt"
 	"strings"
+
+	"github.com/usadamasa/kubectl-localmesh/internal/port"
 )
 
 // ServiceSummary はサービスのサマリー情報を表します。
@@ -16,11 +18,11 @@ type ServiceSummary struct {
 	// Backend はバックエンドの情報
 	Backend string
 	// ListenPort はリスナーポート（0の場合はデフォルトを使用）
-	ListenPort int
+	ListenPort port.ListenerPort
 }
 
 // EffectiveListenPort はListenPortが0の場合はデフォルトポートを返します。
-func (s ServiceSummary) EffectiveListenPort(defaultPort int) int {
+func (s ServiceSummary) EffectiveListenPort(defaultPort port.ListenerPort) port.ListenerPort {
 	if s.ListenPort > 0 {
 		return s.ListenPort
 	}
@@ -42,7 +44,7 @@ func formatProtocolLabel(protocol string) string {
 }
 
 // GenerateSummary はサービスメッシュ起動完了時のサマリーを生成します。
-func GenerateSummary(services []ServiceSummary, listenerPort int) string {
+func GenerateSummary(services []ServiceSummary, listenerPort port.ListenerPort) string {
 	var sb strings.Builder
 
 	sb.WriteString("\nService Mesh is ready!\n\n")
@@ -62,10 +64,10 @@ func GenerateSummary(services []ServiceSummary, listenerPort int) string {
 	if len(httpServices) > 0 {
 		sb.WriteString("  HTTP/gRPC Services:\n")
 		for _, svc := range httpServices {
-			port := svc.EffectiveListenPort(listenerPort)
+			p := svc.EffectiveListenPort(listenerPort)
 			protocolLabel := formatProtocolLabel(svc.Protocol)
 			sb.WriteString(fmt.Sprintf("  • http://%s:%d (%s) -> %s\n",
-				svc.Host, port, protocolLabel, svc.Backend))
+				svc.Host, p, protocolLabel, svc.Backend))
 		}
 		sb.WriteString("\n")
 	}
@@ -74,9 +76,9 @@ func GenerateSummary(services []ServiceSummary, listenerPort int) string {
 	if len(tcpServices) > 0 {
 		sb.WriteString("  TCP Services:\n")
 		for _, svc := range tcpServices {
-			port := svc.EffectiveListenPort(listenerPort)
+			p := svc.EffectiveListenPort(listenerPort)
 			sb.WriteString(fmt.Sprintf("  • tcp://%s:%d -> %s\n",
-				svc.Host, port, svc.Backend))
+				svc.Host, p, svc.Backend))
 		}
 		sb.WriteString("\n")
 	}

--- a/internal/log/summary_test.go
+++ b/internal/log/summary_test.go
@@ -3,6 +3,8 @@ package log
 import (
 	"strings"
 	"testing"
+
+	"github.com/usadamasa/kubectl-localmesh/internal/port"
 )
 
 func TestGenerateSummary_HTTPAndGRPCServices(t *testing.T) {
@@ -168,8 +170,8 @@ func TestServiceSummary_EffectiveListenPort(t *testing.T) {
 	tests := []struct {
 		name           string
 		summary        ServiceSummary
-		defaultPort    int
-		wantListenPort int
+		defaultPort    port.ListenerPort
+		wantListenPort port.ListenerPort
 	}{
 		{
 			name: "use default port when ListenPort is 0",

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -87,7 +87,7 @@ func Run(ctx context.Context, cfg *config.Config, logLevel string, updateHosts b
 	logger.Debugf("listen: 0.0.0.0:%d", cfg.ListenerPort)
 
 	// サマリー出力
-	summary := log.GenerateSummary(visitor.GetServiceSummaries(), int(cfg.ListenerPort))
+	summary := log.GenerateSummary(visitor.GetServiceSummaries(), cfg.ListenerPort)
 	logger.Info(summary)
 
 	envoyCmd := exec.CommandContext(

--- a/internal/snapshot/mapping.go
+++ b/internal/snapshot/mapping.go
@@ -47,8 +47,8 @@ func BuildMappings(configs []envoy.ServiceConfig) PortForwardMappingSet {
 				Namespace:          builder.Namespace,
 				Service:            builder.ServiceName,
 				PortName:           builder.PortName,
-				ResolvedRemotePort: cfg.ResolvedRemotePort,
-				AssignedLocalPort:  cfg.LocalPort,
+				ResolvedRemotePort: int(cfg.ResolvedRemotePort),
+				AssignedLocalPort:  int(cfg.LocalPort),
 				EnvoyClusterName:   cfg.ClusterName,
 			}
 
@@ -70,7 +70,7 @@ func BuildMappings(configs []envoy.ServiceConfig) PortForwardMappingSet {
 				SSHBastion:           builder.SSHBastion,
 				TargetHost:           builder.TargetHost,
 				TargetPort:           int(builder.TargetPort),
-				AssignedLocalPort:    cfg.LocalPort,
+				AssignedLocalPort:    int(cfg.LocalPort),
 				AssignedListenerPort: int(builder.ListenPort),
 				EnvoyClusterName:     cfg.ClusterName,
 			}


### PR DESCRIPTION
セマンティック型（LocalPort, ServicePort, TCPPort等）を関数に直接渡せるように Port型をinterfaceに変更した。

- Port型をジェネリック型制約 `interface { ~int }` に変更
- LocalPort型を新設（FreeLocalPort()の戻り値用）
- IsValid/IsPrivilegedをメソッドから関数に変換
- ValidatePort等のバリデーション関数をジェネリクス化
- RegisterPort関数を新設（Go制約: メソッドは型パラメータを持てない）
- k8s/gcp/config/envoy/run/log各パッケージのシグネチャを更新
- 各パッケージからint()キャストを削除