### PR TITLE
feat: loopback IPエイリアスによるTCPサービスの同一ポート対応

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,6 +100,14 @@ DB (Cloud SQL等、Private IP)
    - ユーザーフレンドリーなサマリー出力
    - `Logger`型によるログ出力の抽象化
 
+10. **loopback** (`internal/loopback/`)
+    - **macOS限定機能**
+    - loopback IPエイリアス管理（TCPサービス用）
+    - `IPAllocator`: 127.0.0.2〜127.0.0.254から順次IPを割り当て
+    - `AliasManager`: `ifconfig lo0 alias`による追加・削除
+    - 複数TCPサービスが同じポート（例: 5432）を使用する場合の重複回避
+    - 起動時にエイリアス追加、終了時にdeferで自動削除
+
 ## 開発ワークフロー
 
 このプロジェクトでは、開発タスクの実行に[Task](https://taskfile.dev)を使用します。
@@ -167,6 +175,17 @@ kubectl-localmeshにおけるログレベル設計とユーザーフレンドリ
 - forbidigo lintルールの説明
 
 詳細: `.claude/skills/kubectl-localmesh-logging-guide/SKILL.md`
+
+#### `kubectl-localmesh-macos-localhost` - macOS .localhostドメインの挙動
+macOSにおける.localhostドメインの特殊な挙動と、TCPサービス設定時の注意点を提供します。
+
+**主な機能**:
+- macOSが`.localhost`を特別扱いする理由（RFC 6761）
+- TCPサービスで`.localhost`が動作しない原因と解決策
+- 推奨TLD（`.localdomain`など）
+- 診断コマンド
+
+詳細: `.claude/skills/kubectl-localmesh-macos-localhost/SKILL.md`
 
 ### クイックスタート
 

--- a/.claude/skills/kubectl-localmesh-macos-localhost/SKILL.md
+++ b/.claude/skills/kubectl-localmesh-macos-localhost/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: kubectl-localmesh-macos-localhost
+description: macOSにおける.localhostドメインの特殊な挙動と、TCPサービス設定時の注意点を提供します
+allowed-tools: ["Bash", "Read"]
+---
+
+# macOSにおける.localhostドメインの挙動
+
+このskillは、macOSが`.localhost`ドメインを特別に扱う挙動と、kubectl-localmeshのTCPサービス設定への影響について説明します。
+
+## 概要
+
+macOSはRFC 6761に基づき、`.localhost` TLDを予約済みドメインとして特別扱いします。
+その結果、`.localhost`のサブドメインは**`/etc/hosts`の設定を無視**して、常に`127.0.0.1`または`::1`に解決されます。
+
+## 問題が発生するケース
+
+### TCPサービス（DB接続など）で.localhostを使用した場合
+
+```yaml
+# 設定ファイル（services.yaml）
+services:
+  - kind: tcp
+    host: db.localhost      # ← これは動かない
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 5432
+```
+
+**期待される動作**:
+- kubectl-localmeshが`/etc/hosts`に`127.0.0.2 db.localhost`を追加
+- クライアントが`db.localhost:5432`に接続
+- `127.0.0.2:5432`（Envoy）に到達
+
+**実際の動作（macOS）**:
+- `/etc/hosts`に`127.0.0.2 db.localhost`が追加される
+- クライアントが`db.localhost:5432`に接続
+- **macOSが`/etc/hosts`を無視**し、`127.0.0.1:5432`に接続しようとする
+- Envoyは`127.0.0.2:5432`でリッスンしているため接続失敗
+
+## 確認方法
+
+```bash
+# /etc/hostsの内容を確認
+$ cat /etc/hosts | grep db
+127.0.0.2 db.localhost
+
+# macOSのDNS解決を確認
+$ python3 -c "import socket; print(socket.gethostbyname('db.localhost'))"
+127.0.0.1
+
+# pingでも確認可能
+$ ping -c 1 db.localhost
+PING localhost (127.0.0.1): 56 data bytes
+```
+
+`/etc/hosts`には`127.0.0.2`と書いてあるのに、`127.0.0.1`に解決されているのが問題です。
+
+## 解決方法
+
+### TCPサービスには.localhost以外のTLDを使用する
+
+```yaml
+# OK: .localdomain を使用
+services:
+  - kind: tcp
+    host: db.localdomain   # ← これは動く
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 5432
+```
+
+### 推奨TLD
+
+| TLD | 説明 |
+|-----|------|
+| `.localdomain` | 一般的なローカル用TLD |
+| `.local` | mDNS/Bonjourでも使用されるが、/etc/hostsが優先される |
+| `.dev` | 開発用（ただしHTTPS強制される場合あり） |
+| `.test` | RFC 2606で予約されたテスト用TLD |
+
+### 自動警告
+
+kubectl-localmeshは、TCPサービスで`.localhost`ドメインが使用された場合、起動時に警告を出力します：
+
+```
+Warning: TCP service 'db.localhost' uses .localhost domain (db.localhost)
+  macOS ignores /etc/hosts for .localhost subdomains and resolves them to 127.0.0.1
+  This may cause connection failures. Consider using .localdomain or another TLD instead.
+```
+
+## なぜHTTP/gRPCサービスは.localhostで動くのか
+
+HTTP/gRPCサービスは仕組みが異なります：
+
+- Envoyが`0.0.0.0:80`（全インターフェース）でリッスン
+- ホストヘッダー（`Host: users-api.localhost`）でルーティング
+- macOSが`.localhost`を`127.0.0.1`に解決しても、`127.0.0.1:80`でEnvoyに到達
+- Envoyがホストヘッダーを見て正しいバックエンドにルーティング
+
+**結論**: HTTP/gRPCは`.localhost`で問題なし、TCPは`.localhost`を避けること
+
+## 技術的背景
+
+### RFC 6761 - Special-Use Domain Names
+
+RFC 6761は、以下のドメインを「特別な用途」として定義しています：
+
+- `.localhost` - ローカルホスト用
+- `.invalid` - 明らかに無効なドメイン
+- `.test` - テスト用
+- `.example` - ドキュメント例示用
+
+### macOSの実装
+
+macOS（Darwin）は、`localhost`およびその全てのサブドメインを、DNSクエリやhostsファイル参照なしに、直接`127.0.0.1`/`::1`に解決します。
+
+これはセキュリティ上の理由（DNSリバインディング攻撃の防止など）からの設計判断です。
+
+## 診断コマンド
+
+```bash
+# /etc/hostsの確認
+cat /etc/hosts
+
+# macOSのDNS解決確認
+python3 -c "import socket; print(socket.gethostbyname('your-host.localhost'))"
+
+# dscacheutilでの確認
+dscacheutil -q host -a name your-host.localhost
+
+# Envoyのリッスン状態確認
+sudo lsof -i :5432
+
+# loopbackエイリアス確認
+ifconfig lo0 | grep inet
+```
+
+## 参考情報
+
+- [RFC 6761 - Special-Use Domain Names](https://www.rfc-editor.org/rfc/rfc6761)
+- [macOS Network Configuration](https://developer.apple.com/documentation/systemconfiguration)
+
+## 関連Skills
+
+- `kubectl-localmesh-operations`: 起動・運用全般
+- `kubectl-envoy-debugging`: Envoy設定のデバッグ

--- a/.claude/skills/kubectl-localmesh-operations/SKILL.md
+++ b/.claude/skills/kubectl-localmesh-operations/SKILL.md
@@ -279,3 +279,4 @@ curl http://users-api.localhost/problematic-endpoint
 
 - `go-taskfile-workflow`: ビルドとテスト
 - `kubectl-envoy-debugging`: Envoy設定の確認とデバッグ
+- `kubectl-localmesh-macos-localhost`: macOSの.localhostドメインの挙動

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ brew install envoy
 gcloud auth application-default login
 ```
 
+> **macOS TCP Support:** When running multiple TCP services (e.g., multiple databases on port 5432), kubectl-localmesh automatically assigns loopback IP aliases (127.0.0.x) using `ifconfig lo0 alias`. This requires `sudo` and is automatically cleaned up on exit.
+
 ## Usage
 
 ### Configuration file

--- a/internal/envoy/tcp_test.go
+++ b/internal/envoy/tcp_test.go
@@ -1,0 +1,112 @@
+package envoy
+
+import (
+	"testing"
+
+	"github.com/usadamasa/kubectl-localmesh/internal/port"
+)
+
+func TestTCPServiceBuilder_Build(t *testing.T) {
+	t.Run("ListenAddrが設定されている場合はそのアドレスを使用", func(t *testing.T) {
+		builder := NewTCPServiceBuilder(
+			"db.localhost",
+			port.TCPPort(5432),
+			"127.0.0.5", // ListenAddr
+			"primary",
+			"10.0.0.1",
+			port.TCPPort(5432),
+		)
+
+		components := builder.Build("tcp_db", 12345)
+
+		// リスナー設定を確認
+		listener := components.Listener
+		address, ok := listener["address"].(map[string]any)
+		if !ok {
+			t.Fatal("address not found in listener")
+		}
+		socketAddr, ok := address["socket_address"].(map[string]any)
+		if !ok {
+			t.Fatal("socket_address not found in address")
+		}
+
+		// ListenAddrが使用されていることを確認
+		if socketAddr["address"] != "127.0.0.5" {
+			t.Errorf("expected address 127.0.0.5, got %v", socketAddr["address"])
+		}
+		if socketAddr["port_value"] != 5432 {
+			t.Errorf("expected port_value 5432, got %v", socketAddr["port_value"])
+		}
+	})
+
+	t.Run("クラスタ設定が正しく生成される", func(t *testing.T) {
+		builder := NewTCPServiceBuilder(
+			"db.localhost",
+			port.TCPPort(5432),
+			"127.0.0.2",
+			"primary",
+			"10.0.0.1",
+			port.TCPPort(5432),
+		)
+
+		components := builder.Build("tcp_db", 54321)
+
+		// クラスタ設定を確認
+		cluster := components.Cluster
+		if cluster["name"] != "tcp_db" {
+			t.Errorf("expected cluster name tcp_db, got %v", cluster["name"])
+		}
+
+		// ロードアサインメントを確認
+		loadAssignment, ok := cluster["load_assignment"].(map[string]any)
+		if !ok {
+			t.Fatal("load_assignment not found")
+		}
+		endpoints, ok := loadAssignment["endpoints"].([]any)
+		if !ok || len(endpoints) == 0 {
+			t.Fatal("endpoints not found or empty")
+		}
+		ep := endpoints[0].(map[string]any)
+		lbEndpoints := ep["lb_endpoints"].([]any)
+		endpoint := lbEndpoints[0].(map[string]any)["endpoint"].(map[string]any)
+		addr := endpoint["address"].(map[string]any)["socket_address"].(map[string]any)
+
+		// ローカルポートへ接続することを確認
+		if addr["address"] != "127.0.0.1" {
+			t.Errorf("expected cluster endpoint 127.0.0.1, got %v", addr["address"])
+		}
+		if addr["port_value"] != 54321 {
+			t.Errorf("expected cluster port 54321, got %v", addr["port_value"])
+		}
+	})
+}
+
+func TestTCPServiceBuilder_GetHost(t *testing.T) {
+	builder := NewTCPServiceBuilder(
+		"mydb.localhost",
+		port.TCPPort(3306),
+		"127.0.0.3",
+		"bastion",
+		"10.0.0.5",
+		port.TCPPort(3306),
+	)
+
+	if builder.GetHost() != "mydb.localhost" {
+		t.Errorf("expected mydb.localhost, got %s", builder.GetHost())
+	}
+}
+
+func TestTCPServiceBuilder_GetListenAddr(t *testing.T) {
+	builder := NewTCPServiceBuilder(
+		"mydb.localhost",
+		port.TCPPort(3306),
+		"127.0.0.42",
+		"bastion",
+		"10.0.0.5",
+		port.TCPPort(3306),
+	)
+
+	if builder.GetListenAddr() != "127.0.0.42" {
+		t.Errorf("expected 127.0.0.42, got %s", builder.GetListenAddr())
+	}
+}

--- a/internal/hosts/hosts_test.go
+++ b/internal/hosts/hosts_test.go
@@ -243,6 +243,43 @@ func TestNormalizeFileEnding(t *testing.T) {
 	}
 }
 
+// TestAddEntriesWithIPs_DifferentIPs は、異なるIPアドレスを持つエントリの追加をテストする
+func TestAddEntriesWithIPs_DifferentIPs(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "hosts")
+	setTestHostsFile(t, testFile)
+
+	// 空ファイルを作成
+	if err := os.WriteFile(testFile, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	entries := []HostEntry{
+		{Hostname: "db1.localhost", IP: "127.0.0.2"},
+		{Hostname: "db2.localhost", IP: "127.0.0.3"},
+		{Hostname: "api.localhost", IP: "127.0.0.1"},
+	}
+
+	if err := AddEntriesWithIPs(entries); err != nil {
+		t.Fatalf("AddEntriesWithIPs failed: %v", err)
+	}
+
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("failed to read test file: %v", err)
+	}
+
+	expected := markerStart + "\n" +
+		"127.0.0.2 db1.localhost\n" +
+		"127.0.0.3 db2.localhost\n" +
+		"127.0.0.1 api.localhost\n" +
+		markerEnd + "\n"
+
+	if string(content) != expected {
+		t.Errorf("unexpected content:\ngot:\n%q\nwant:\n%q", string(content), expected)
+	}
+}
+
 // TestTrimTrailingEmptyLines は、trimTrailingEmptyLines関数のユニットテスト
 func TestTrimTrailingEmptyLines(t *testing.T) {
 	tests := []struct {

--- a/internal/loopback/ifconfig.go
+++ b/internal/loopback/ifconfig.go
@@ -1,0 +1,80 @@
+package loopback
+
+import (
+	"os/exec"
+)
+
+// CommandExecutor はコマンド実行の抽象化（テスト用）
+type CommandExecutor func(name string, args ...string) error
+
+// defaultExecutor は実際のifconfigコマンドを実行する
+func defaultExecutor(name string, args ...string) error {
+	return exec.Command(name, args...).Run()
+}
+
+// AliasManager はloopback IPエイリアスの追加・削除を管理
+type AliasManager struct {
+	executor CommandExecutor
+	added    []string // 追加成功したIPを追跡
+}
+
+// NewAliasManager は新しいAliasManagerを生成
+func NewAliasManager() *AliasManager {
+	return &AliasManager{
+		executor: defaultExecutor,
+		added:    make([]string, 0),
+	}
+}
+
+// AddAlias は指定されたIPをlo0のエイリアスとして追加
+// 成功した場合のみ内部で追跡し、RemoveAddedで削除可能にする
+// sudo ifconfig lo0 alias <ip> up
+func (m *AliasManager) AddAlias(ip string) error {
+	if err := m.executor("ifconfig", "lo0", "alias", ip, "up"); err != nil {
+		return err
+	}
+	m.added = append(m.added, ip)
+	return nil
+}
+
+// GetAdded は追加成功したIPのリストをコピーとして返す
+func (m *AliasManager) GetAdded() []string {
+	result := make([]string, len(m.added))
+	copy(result, m.added)
+	return result
+}
+
+// RemoveAdded は追加成功したIPを全て削除する
+// 削除時のエラーは無視する（クリーンアップ用途のため）
+func (m *AliasManager) RemoveAdded() {
+	for _, ip := range m.added {
+		_ = m.executor("ifconfig", "lo0", "-alias", ip)
+	}
+	m.added = nil
+}
+
+// RemoveAlias は指定されたIPをlo0のエイリアスから削除
+// sudo ifconfig lo0 -alias <ip>
+func (m *AliasManager) RemoveAlias(ip string) error {
+	return m.executor("ifconfig", "lo0", "-alias", ip)
+}
+
+// AddAliases は複数のIPをエイリアスとして追加
+func (m *AliasManager) AddAliases(ips []string) error {
+	for _, ip := range ips {
+		if err := m.AddAlias(ip); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveAliases は複数のIPをエイリアスから削除
+// エラーは無視して継続する（クリーンアップ用途のため）
+func (m *AliasManager) RemoveAliases(ips []string) error {
+	for _, ip := range ips {
+		// エラーは無視（エイリアスが存在しない場合など）
+		_ = m.RemoveAlias(ip)
+	}
+	return nil
+}

--- a/internal/loopback/ifconfig_test.go
+++ b/internal/loopback/ifconfig_test.go
@@ -1,0 +1,244 @@
+package loopback
+
+import (
+	"testing"
+)
+
+func TestAliasManager_AddAlias(t *testing.T) {
+	t.Run("ifconfigコマンドが正しい引数で呼ばれる", func(t *testing.T) {
+		var calledArgs []string
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error {
+				calledArgs = args
+				return nil
+			},
+		}
+
+		err := mgr.AddAlias("127.0.0.2")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := []string{"lo0", "alias", "127.0.0.2", "up"}
+		if len(calledArgs) != len(expected) {
+			t.Errorf("expected %d args, got %d", len(expected), len(calledArgs))
+		}
+		for i, exp := range expected {
+			if i < len(calledArgs) && calledArgs[i] != exp {
+				t.Errorf("arg %d: expected %s, got %s", i, exp, calledArgs[i])
+			}
+		}
+	})
+}
+
+func TestAliasManager_RemoveAlias(t *testing.T) {
+	t.Run("ifconfigコマンドが正しい引数で呼ばれる", func(t *testing.T) {
+		var calledArgs []string
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error {
+				calledArgs = args
+				return nil
+			},
+		}
+
+		err := mgr.RemoveAlias("127.0.0.2")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := []string{"lo0", "-alias", "127.0.0.2"}
+		if len(calledArgs) != len(expected) {
+			t.Errorf("expected %d args, got %d", len(expected), len(calledArgs))
+		}
+		for i, exp := range expected {
+			if i < len(calledArgs) && calledArgs[i] != exp {
+				t.Errorf("arg %d: expected %s, got %s", i, exp, calledArgs[i])
+			}
+		}
+	})
+}
+
+func TestAliasManager_AddAliases(t *testing.T) {
+	t.Run("複数のエイリアスを追加", func(t *testing.T) {
+		var callCount int
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error {
+				callCount++
+				return nil
+			},
+		}
+
+		ips := []string{"127.0.0.2", "127.0.0.3", "127.0.0.4"}
+		err := mgr.AddAliases(ips)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if callCount != 3 {
+			t.Errorf("expected 3 calls, got %d", callCount)
+		}
+	})
+
+	t.Run("空のリストでは何もしない", func(t *testing.T) {
+		var callCount int
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error {
+				callCount++
+				return nil
+			},
+		}
+
+		err := mgr.AddAliases([]string{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if callCount != 0 {
+			t.Errorf("expected 0 calls, got %d", callCount)
+		}
+	})
+}
+
+func TestAliasManager_RemoveAliases(t *testing.T) {
+	t.Run("複数のエイリアスを削除", func(t *testing.T) {
+		var callCount int
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error {
+				callCount++
+				return nil
+			},
+		}
+
+		ips := []string{"127.0.0.2", "127.0.0.3", "127.0.0.4"}
+		err := mgr.RemoveAliases(ips)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if callCount != 3 {
+			t.Errorf("expected 3 calls, got %d", callCount)
+		}
+	})
+
+	t.Run("削除エラーは無視して継続", func(t *testing.T) {
+		var callCount int
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error {
+				callCount++
+				// エラーを返しても継続する
+				return &mockError{msg: "alias not found"}
+			},
+		}
+
+		ips := []string{"127.0.0.2", "127.0.0.3"}
+		// RemoveAliasesはエラーを無視する（クリーンアップ用途のため）
+		err := mgr.RemoveAliases(ips)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if callCount != 2 {
+			t.Errorf("expected 2 calls, got %d", callCount)
+		}
+	})
+}
+
+type mockError struct {
+	msg string
+}
+
+func (e *mockError) Error() string {
+	return e.msg
+}
+
+func TestAliasManager_TracksAddedIPs(t *testing.T) {
+	t.Run("AddAlias成功時にaddedに追加", func(t *testing.T) {
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error {
+				return nil
+			},
+			added: make([]string, 0),
+		}
+
+		_ = mgr.AddAlias("127.0.0.2")
+		_ = mgr.AddAlias("127.0.0.3")
+
+		added := mgr.GetAdded()
+		if len(added) != 2 {
+			t.Errorf("expected 2 added IPs, got %d", len(added))
+		}
+		if added[0] != "127.0.0.2" {
+			t.Errorf("expected 127.0.0.2, got %s", added[0])
+		}
+		if added[1] != "127.0.0.3" {
+			t.Errorf("expected 127.0.0.3, got %s", added[1])
+		}
+	})
+
+	t.Run("AddAlias失敗時はaddedに追加しない", func(t *testing.T) {
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error {
+				return &mockError{msg: "permission denied"}
+			},
+			added: make([]string, 0),
+		}
+
+		_ = mgr.AddAlias("127.0.0.2")
+
+		added := mgr.GetAdded()
+		if len(added) != 0 {
+			t.Errorf("expected 0 added IPs after failure, got %d", len(added))
+		}
+	})
+
+	t.Run("RemoveAddedは追加成功分のみ削除", func(t *testing.T) {
+		var removed []string
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error {
+				// args = ["lo0", "-alias", "127.0.0.x"]
+				if len(args) >= 3 && args[1] == "-alias" {
+					removed = append(removed, args[2])
+				}
+				return nil
+			},
+			added: make([]string, 0),
+		}
+
+		_ = mgr.AddAlias("127.0.0.2")
+		_ = mgr.AddAlias("127.0.0.3")
+
+		mgr.RemoveAdded()
+
+		if len(removed) != 2 {
+			t.Errorf("expected 2 removed, got %d", len(removed))
+		}
+		if len(removed) >= 1 && removed[0] != "127.0.0.2" {
+			t.Errorf("expected 127.0.0.2, got %s", removed[0])
+		}
+		if len(removed) >= 2 && removed[1] != "127.0.0.3" {
+			t.Errorf("expected 127.0.0.3, got %s", removed[1])
+		}
+
+		// RemoveAdded後はaddedがクリアされていること
+		if len(mgr.GetAdded()) != 0 {
+			t.Errorf("expected added to be cleared after RemoveAdded, got %d", len(mgr.GetAdded()))
+		}
+	})
+
+	t.Run("GetAddedはコピーを返す", func(t *testing.T) {
+		mgr := &AliasManager{
+			executor: func(name string, args ...string) error { return nil },
+			added:    make([]string, 0),
+		}
+
+		_ = mgr.AddAlias("127.0.0.2")
+		added := mgr.GetAdded()
+
+		// 外部から変更しても内部には影響しない
+		added[0] = "modified"
+		internalAdded := mgr.GetAdded()
+		if internalAdded[0] != "127.0.0.2" {
+			t.Errorf("expected internal state to be unchanged, got %s", internalAdded[0])
+		}
+	})
+}

--- a/internal/loopback/ip.go
+++ b/internal/loopback/ip.go
@@ -1,0 +1,80 @@
+// Package loopback は、TCPサービス用のloopback IPエイリアス管理を提供する
+// macOS限定機能（ifconfig lo0 aliasを使用）
+package loopback
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+// IPChecker はIPアドレスが使用中かを判定する関数型
+type IPChecker func(ip string) bool
+
+// IPAllocator は127.0.0.x系のIPアドレスを順次割り当てる
+// 127.0.0.1は常に使用中のため除外し、127.0.0.2〜127.0.0.254から採番する
+type IPAllocator struct {
+	nextOctet int       // 次に割り当てるオクテット（2〜254）
+	allocated []string  // 割り当て済みIPリスト
+	isInUse   IPChecker // 使用中IPチェッカー
+}
+
+// NewIPAllocator は新しいIPAllocatorを生成（デフォルトチェッカー使用）
+func NewIPAllocator() *IPAllocator {
+	return NewIPAllocatorWithChecker(defaultIPChecker)
+}
+
+// NewIPAllocatorWithChecker はカスタムチェッカーでIPAllocatorを生成（テスト用）
+func NewIPAllocatorWithChecker(checker IPChecker) *IPAllocator {
+	return &IPAllocator{
+		nextOctet: 2, // 127.0.0.2から開始
+		allocated: make([]string, 0),
+		isInUse:   checker,
+	}
+}
+
+// defaultIPChecker はlo0インターフェースの既存IPをチェック
+func defaultIPChecker(ip string) bool {
+	iface, err := net.InterfaceByName("lo0")
+	if err != nil {
+		return false
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return false
+	}
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok {
+			if ipnet.IP.String() == ip {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Allocate は次の利用可能なloopback IPを返す
+// 使用中IPをスキップし、利用可能なIPがない場合はエラーを返す
+func (a *IPAllocator) Allocate() (string, error) {
+	for a.nextOctet <= 254 {
+		ip := fmt.Sprintf("127.0.0.%d", a.nextOctet)
+		a.nextOctet++
+		if !a.isInUse(ip) {
+			a.allocated = append(a.allocated, ip)
+			return ip, nil
+		}
+	}
+	return "", errors.New("loopback IP range exhausted (127.0.0.2-254)")
+}
+
+// GetAliases は追加が必要なエイリアスIPのリストを返す
+// 127.0.0.2以降を使用するため、全てがエイリアス対象
+func (a *IPAllocator) GetAliases() []string {
+	return a.allocated
+}
+
+// Reset はアロケータをリセットして再利用可能にする
+func (a *IPAllocator) Reset() {
+	a.nextOctet = 2
+	a.allocated = make([]string, 0)
+}

--- a/internal/loopback/ip_test.go
+++ b/internal/loopback/ip_test.go
@@ -1,0 +1,167 @@
+package loopback
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIPAllocator_Allocate(t *testing.T) {
+	t.Run("割り当てられたIPは127.0.0.x形式", func(t *testing.T) {
+		alloc := NewIPAllocator()
+		ip, err := alloc.Allocate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.HasPrefix(ip, "127.0.0.") {
+			t.Errorf("expected 127.0.0.x format, got %s", ip)
+		}
+	})
+
+	t.Run("連続割り当てで全て異なるIPが返される", func(t *testing.T) {
+		alloc := NewIPAllocator()
+		seen := make(map[string]bool)
+		for i := 0; i < 10; i++ {
+			ip, err := alloc.Allocate()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if seen[ip] {
+				t.Errorf("duplicate IP allocated: %s", ip)
+			}
+			seen[ip] = true
+		}
+	})
+
+	t.Run("最大253個まで割り当て可能", func(t *testing.T) {
+		alloc := NewIPAllocator()
+		seen := make(map[string]bool)
+		for i := 0; i < 253; i++ {
+			ip, err := alloc.Allocate()
+			if err != nil {
+				t.Fatalf("unexpected error at %d: %v", i, err)
+			}
+			if seen[ip] {
+				t.Errorf("duplicate IP allocated at %d: %s", i, ip)
+			}
+			seen[ip] = true
+			if !strings.HasPrefix(ip, "127.0.0.") {
+				t.Errorf("expected 127.0.0.x format, got %s", ip)
+			}
+		}
+	})
+
+	t.Run("順次割り当てで127.0.0.2から開始", func(t *testing.T) {
+		alloc := NewIPAllocator()
+		ip1, err := alloc.Allocate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		ip2, err := alloc.Allocate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		ip3, err := alloc.Allocate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ip1 != "127.0.0.2" {
+			t.Errorf("expected 127.0.0.2, got %s", ip1)
+		}
+		if ip2 != "127.0.0.3" {
+			t.Errorf("expected 127.0.0.3, got %s", ip2)
+		}
+		if ip3 != "127.0.0.4" {
+			t.Errorf("expected 127.0.0.4, got %s", ip3)
+		}
+	})
+}
+
+func TestIPAllocator_Allocate_SkipsInUseIPs(t *testing.T) {
+	t.Run("使用中IPをスキップ", func(t *testing.T) {
+		alloc := NewIPAllocatorWithChecker(func(ip string) bool {
+			// 127.0.0.2 と 127.0.0.4 は使用中として扱う
+			return ip == "127.0.0.2" || ip == "127.0.0.4"
+		})
+
+		ip1, err := alloc.Allocate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ip1 != "127.0.0.3" {
+			t.Errorf("expected 127.0.0.3, got %s", ip1)
+		}
+
+		ip2, err := alloc.Allocate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ip2 != "127.0.0.5" {
+			t.Errorf("expected 127.0.0.5, got %s", ip2)
+		}
+	})
+
+	t.Run("全IP使用中でエラー", func(t *testing.T) {
+		alloc := NewIPAllocatorWithChecker(func(ip string) bool {
+			return true // 全てのIPが使用中
+		})
+
+		_, err := alloc.Allocate()
+		if err == nil {
+			t.Error("expected error when all IPs are in use")
+		}
+	})
+
+	t.Run("カスタムチェッカーなしでデフォルト動作", func(t *testing.T) {
+		// NewIPAllocator() はデフォルトチェッカーを使用
+		alloc := NewIPAllocator()
+		ip, err := alloc.Allocate()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.HasPrefix(ip, "127.0.0.") {
+			t.Errorf("expected 127.0.0.x format, got %s", ip)
+		}
+	})
+}
+
+func TestIPAllocator_GetAliases(t *testing.T) {
+	t.Run("割り当てた全てのIPがエイリアスとして返される", func(t *testing.T) {
+		alloc := NewIPAllocator()
+		_, _ = alloc.Allocate()
+		aliases := alloc.GetAliases()
+		if len(aliases) != 1 {
+			t.Errorf("expected 1 alias, got %d", len(aliases))
+		}
+	})
+
+	t.Run("5つ割り当てた場合は5つのエイリアス", func(t *testing.T) {
+		alloc := NewIPAllocator()
+		for i := 0; i < 5; i++ {
+			_, _ = alloc.Allocate()
+		}
+		aliases := alloc.GetAliases()
+		if len(aliases) != 5 {
+			t.Errorf("expected 5 aliases, got %d", len(aliases))
+		}
+		// 全てのエイリアスは127.0.0.x形式
+		for _, alias := range aliases {
+			if !strings.HasPrefix(alias, "127.0.0.") {
+				t.Errorf("expected 127.0.0.x format, got %s", alias)
+			}
+		}
+	})
+}
+
+func TestIPAllocator_Reset(t *testing.T) {
+	t.Run("リセット後はエイリアスもクリア", func(t *testing.T) {
+		alloc := NewIPAllocator()
+		for i := 0; i < 5; i++ {
+			_, _ = alloc.Allocate()
+		}
+		alloc.Reset()
+		aliases := alloc.GetAliases()
+		if len(aliases) != 0 {
+			t.Errorf("expected 0 aliases after reset, got %d", len(aliases))
+		}
+	})
+}

--- a/internal/port/port.go
+++ b/internal/port/port.go
@@ -73,6 +73,11 @@ func ValidatePorts[T Port](ports []T, fieldName, serviceName string) error {
 // warnWriter は警告出力先（テスト時に差し替え可能）
 var warnWriter io.Writer = os.Stderr
 
+// WarnWriter は現在の警告出力先を取得（テスト用）
+func WarnWriter() io.Writer {
+	return warnWriter
+}
+
 // SetWarnWriter は警告出力先を設定（テスト用）
 func SetWarnWriter(w io.Writer) {
 	warnWriter = w
@@ -87,25 +92,99 @@ func WarnPrivilegedPort[T Port](port T, fieldName, serviceName string) {
 	}
 }
 
+// WarnLocalhostTLD はTCPサービスで.localhostドメインを使用した場合の警告を出力
+// macOSでは.localhostサブドメインは/etc/hostsを無視して127.0.0.1に解決されるため、
+// 異なるloopback IPにバインドされたTCPサービスに接続できない
+func WarnLocalhostTLD(hostname, serviceName string) {
+	// ".localhost"で終わるが、"localhost"そのものではない場合に警告
+	if hostname != "localhost" && (hostname == ".localhost" || len(hostname) > 10 && hostname[len(hostname)-10:] == ".localhost") {
+		_, _ = fmt.Fprintf(warnWriter, "Warning: TCP service '%s' uses .localhost domain (%s)\n"+
+			"  macOS ignores /etc/hosts for .localhost subdomains and resolves them to 127.0.0.1\n"+
+			"  This may cause connection failures. Consider using .localdomain or another TLD instead.\n",
+			serviceName, hostname)
+	}
+}
+
 // PortConflictChecker はポート競合を検出するためのヘルパー
 type PortConflictChecker struct {
-	usedPorts map[int]string // port -> service name
+	usedPorts     map[int]string    // port -> service name（IP指定なし）
+	usedAddrPorts map[string]string // "ip:port" -> service name（IP指定あり）
+	wildcardPorts map[int]string    // 0.0.0.0でバインドされたport -> service name
 }
 
 // NewPortConflictChecker は新しいPortConflictCheckerを生成
 func NewPortConflictChecker() *PortConflictChecker {
 	return &PortConflictChecker{
-		usedPorts: make(map[int]string),
+		usedPorts:     make(map[int]string),
+		usedAddrPorts: make(map[string]string),
+		wildcardPorts: make(map[int]string),
 	}
 }
 
-// Register はポートを登録し、競合があれば警告を出力
+// Register はポートを登録し、競合があれば警告を出力（IP指定なし、従来互換）
 func (c *PortConflictChecker) Register(port int, serviceName string) {
 	if existingService, ok := c.usedPorts[port]; ok {
 		_, _ = fmt.Fprintf(warnWriter, "Warning: port %d is used by both '%s' and '%s'\n",
 			port, existingService, serviceName)
 	}
 	c.usedPorts[port] = serviceName
+}
+
+// RegisterWithAddr はIP:portの組み合わせで登録し、競合があれば警告を出力
+// addr が空の場合はポート番号のみでチェック（従来動作）
+// addr が "0.0.0.0" の場合は全インターフェースバインドとして扱う
+func (c *PortConflictChecker) RegisterWithAddr(addr string, port int, serviceName string) {
+	// アドレス指定がない場合は従来の動作
+	if addr == "" {
+		c.Register(port, serviceName)
+		return
+	}
+
+	// 0.0.0.0（ワイルドカード）の場合
+	if addr == "0.0.0.0" {
+		// 既存のワイルドカードポートと競合チェック
+		if existingService, ok := c.wildcardPorts[port]; ok {
+			_, _ = fmt.Fprintf(warnWriter, "Warning: 0.0.0.0:%d is used by both '%s' and '%s'\n",
+				port, existingService, serviceName)
+		}
+		// 既存の特定IPポートと競合チェック
+		for key, existingService := range c.usedAddrPorts {
+			existingPort := extractPort(key)
+			if existingPort == port {
+				_, _ = fmt.Fprintf(warnWriter, "Warning: port %d conflict - '%s' (0.0.0.0) binds all interfaces, conflicts with '%s' (%s)\n",
+					port, serviceName, existingService, key)
+			}
+		}
+		c.wildcardPorts[port] = serviceName
+		return
+	}
+
+	// 特定IPアドレスの場合
+	key := fmt.Sprintf("%s:%d", addr, port)
+
+	// 既存のワイルドカードポートと競合チェック
+	if existingService, ok := c.wildcardPorts[port]; ok {
+		_, _ = fmt.Fprintf(warnWriter, "Warning: port %d conflict - '%s' (0.0.0.0) binds all interfaces, conflicts with '%s' (%s)\n",
+			port, existingService, serviceName, key)
+	}
+
+	// 同じIP:portと競合チェック
+	if existingService, ok := c.usedAddrPorts[key]; ok {
+		_, _ = fmt.Fprintf(warnWriter, "Warning: %s is used by both '%s' and '%s'\n",
+			key, existingService, serviceName)
+	}
+	c.usedAddrPorts[key] = serviceName
+}
+
+// extractPort は "ip:port" 形式の文字列からポート番号を抽出
+func extractPort(addrPort string) int {
+	_, portStr, err := net.SplitHostPort(addrPort)
+	if err != nil {
+		return 0
+	}
+	var port int
+	_, _ = fmt.Sscanf(portStr, "%d", &port)
+	return port
 }
 
 // RegisterPort はセマンティック型のポートを登録するジェネリック関数

--- a/internal/snapshot/mapping.go
+++ b/internal/snapshot/mapping.go
@@ -20,9 +20,10 @@ type PortForwardMapping struct {
 	TargetPort int    `yaml:"target_port,omitempty"`
 
 	// Common assigned ports
-	AssignedLocalPort     int   `yaml:"assigned_local_port"`
-	AssignedListenerPort  int   `yaml:"assigned_listener_port,omitempty"`  // TCPサービス用
-	AssignedListenerPorts []int `yaml:"assigned_listener_ports,omitempty"` // OverwriteListenPorts用
+	AssignedLocalPort     int    `yaml:"assigned_local_port"`
+	AssignedListenAddr    string `yaml:"assigned_listen_addr,omitempty"`    // TCPサービス用（loopback IP）
+	AssignedListenerPort  int    `yaml:"assigned_listener_port,omitempty"`  // TCPサービス用
+	AssignedListenerPorts []int  `yaml:"assigned_listener_ports,omitempty"` // OverwriteListenPorts用
 
 	// Envoy cluster reference
 	EnvoyClusterName string `yaml:"envoy_cluster_name"`
@@ -71,6 +72,7 @@ func BuildMappings(configs []envoy.ServiceConfig) PortForwardMappingSet {
 				TargetHost:           builder.TargetHost,
 				TargetPort:           int(builder.TargetPort),
 				AssignedLocalPort:    int(cfg.LocalPort),
+				AssignedListenAddr:   builder.ListenAddr,
 				AssignedListenerPort: int(builder.ListenPort),
 				EnvoyClusterName:     cfg.ClusterName,
 			}

--- a/internal/snapshot/mapping_test.go
+++ b/internal/snapshot/mapping_test.go
@@ -48,6 +48,7 @@ func TestPortForwardMapping_YAML(t *testing.T) {
 			TargetHost:           "10.0.0.1",
 			TargetPort:           5432,
 			AssignedLocalPort:    10001,
+			AssignedListenAddr:   "127.0.0.2",
 			AssignedListenerPort: 5432,
 			EnvoyClusterName:     "tcp_primary_10_0_0_1_5432",
 		}
@@ -66,6 +67,7 @@ func TestPortForwardMapping_YAML(t *testing.T) {
 		assertContains(t, got, "target_host: 10.0.0.1")
 		assertContains(t, got, "target_port: 5432")
 		assertContains(t, got, "assigned_local_port: 10001")
+		assertContains(t, got, "assigned_listen_addr: 127.0.0.2")
 		assertContains(t, got, "assigned_listener_port: 5432")
 		assertContains(t, got, "envoy_cluster_name: tcp_primary_10_0_0_1_5432")
 	})
@@ -93,6 +95,7 @@ func TestPortForwardMapping_YAML(t *testing.T) {
 		assertNotContains(t, got, "ssh_bastion")
 		assertNotContains(t, got, "target_host")
 		assertNotContains(t, got, "target_port")
+		assertNotContains(t, got, "assigned_listen_addr")
 		assertNotContains(t, got, "assigned_listener_port")
 	})
 }
@@ -201,7 +204,7 @@ func TestBuildMappings(t *testing.T) {
 
 	t.Run("tcp services", func(t *testing.T) {
 		builder := envoy.NewTCPServiceBuilder(
-			"db.localhost", 5432, "primary", "10.0.0.1", 5432,
+			"db.localhost", 5432, "127.0.0.2", "primary", "10.0.0.1", 5432,
 		)
 		configs := []envoy.ServiceConfig{
 			{
@@ -224,6 +227,7 @@ func TestBuildMappings(t *testing.T) {
 		assertEqual(t, "10.0.0.1", m.TargetHost)
 		assertEqual(t, 5432, m.TargetPort)
 		assertEqual(t, 10002, m.AssignedLocalPort)
+		assertEqual(t, "127.0.0.2", m.AssignedListenAddr)
 		assertEqual(t, 5432, m.AssignedListenerPort)
 		assertEqual(t, "tcp_primary_10_0_0_1_5432", m.EnvoyClusterName)
 	})
@@ -233,7 +237,7 @@ func TestBuildMappings(t *testing.T) {
 			"api.localhost", "http", "default", "api", "http", 0, nil,
 		)
 		tcpBuilder := envoy.NewTCPServiceBuilder(
-			"db.localhost", 5432, "primary", "10.0.0.1", 5432,
+			"db.localhost", 5432, "127.0.0.2", "primary", "10.0.0.1", 5432,
 		)
 		configs := []envoy.ServiceConfig{
 			{

--- a/testdata/envoy-snapshots/testdata/portforward-mappings/mixed-http-tcp-mapping.yaml
+++ b/testdata/envoy-snapshots/testdata/portforward-mappings/mixed-http-tcp-mapping.yaml
@@ -14,6 +14,7 @@ services:
       target_host: 10.0.0.1
       target_port: 5432
       assigned_local_port: 10001
+      assigned_listen_addr: 127.0.0.2
       assigned_listener_port: 5432
       envoy_cluster_name: tcp_primary_10_0_0_1_5432
     - kind: tcp
@@ -22,5 +23,6 @@ services:
       target_host: 10.0.0.2
       target_port: 6379
       assigned_local_port: 10002
+      assigned_listen_addr: 127.0.0.3
       assigned_listener_port: 6379
       envoy_cluster_name: tcp_primary_10_0_0_2_6379

--- a/testdata/envoy-snapshots/testdata/portforward-mappings/multiple-tcp-same-port-mapping.yaml
+++ b/testdata/envoy-snapshots/testdata/portforward-mappings/multiple-tcp-same-port-mapping.yaml
@@ -5,6 +5,7 @@ services:
       target_host: 10.0.0.1
       target_port: 5432
       assigned_local_port: 10000
+      assigned_listen_addr: 127.0.0.2
       assigned_listener_port: 5432
       envoy_cluster_name: tcp_primary_10_0_0_1_5432
     - kind: tcp
@@ -13,5 +14,6 @@ services:
       target_host: 10.0.0.2
       target_port: 5432
       assigned_local_port: 10001
+      assigned_listen_addr: 127.0.0.3
       assigned_listener_port: 5432
       envoy_cluster_name: tcp_primary_10_0_0_2_5432

--- a/testdata/envoy-snapshots/testdata/portforward-mappings/tcp-only-mapping.yaml
+++ b/testdata/envoy-snapshots/testdata/portforward-mappings/tcp-only-mapping.yaml
@@ -5,5 +5,6 @@ services:
       target_host: 10.0.0.1
       target_port: 5432
       assigned_local_port: 10000
+      assigned_listen_addr: 127.0.0.2
       assigned_listener_port: 5432
       envoy_cluster_name: tcp_primary_10_0_0_1_5432

--- a/testdata/envoy-snapshots/testdata/snapshots/mixed-http-tcp.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/mixed-http-tcp.yaml
@@ -85,7 +85,7 @@ static_resources:
           name: listener_http
         - address:
             socket_address:
-                address: 0.0.0.0
+                address: 127.0.0.2
                 port_value: 5432
           enable_reuse_port:
             value: false
@@ -99,7 +99,7 @@ static_resources:
           name: listener_tcp_tcp_primary_10_0_0_1_5432
         - address:
             socket_address:
-                address: 0.0.0.0
+                address: 127.0.0.3
                 port_value: 6379
           enable_reuse_port:
             value: false

--- a/testdata/envoy-snapshots/testdata/snapshots/multiple-tcp-same-port.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/multiple-tcp-same-port.yaml
@@ -36,7 +36,7 @@ static_resources:
     listeners:
         - address:
             socket_address:
-                address: 0.0.0.0
+                address: 127.0.0.2
                 port_value: 5432
           enable_reuse_port:
             value: false
@@ -50,7 +50,7 @@ static_resources:
           name: listener_tcp_tcp_primary_10_0_0_1_5432
         - address:
             socket_address:
-                address: 0.0.0.0
+                address: 127.0.0.3
                 port_value: 5432
           enable_reuse_port:
             value: false

--- a/testdata/envoy-snapshots/testdata/snapshots/tcp-only.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/tcp-only.yaml
@@ -24,7 +24,7 @@ static_resources:
     listeners:
         - address:
             socket_address:
-                address: 0.0.0.0
+                address: 127.0.0.2
                 port_value: 5432
           enable_reuse_port:
             value: false


### PR DESCRIPTION
## Summary

- macOSのloopbackインターフェース（lo0）にIPエイリアス（127.0.0.2〜127.0.0.254）を追加することで、複数のTCPサービスが同じポート番号（例: 5432）を使用できるように対応
- `IPAllocator`で順次IPアドレスを割り当て、`AliasManager`で`ifconfig lo0 alias`コマンドを実行
- 終了時にdeferで自動的にエイリアスを削除
- 関連するスナップショットテストとドキュメントを追加

## Test plan

- [x] `task test`で全テストがパスすることを確認
- [x] `task lint`でlintエラーがないことを確認
- [x] macOSでサービス設定ファイルに複数の同一ポートTCPサービスを記載し、それぞれ別のIPでアクセスできることを確認
- [x] Ctrl+Cでの終了時にIPエイリアスが適切にクリーンアップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)