### PR TITLE
refactor: overwrite_listen_portsをlistener_portに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Think of it as a **shadow gateway** for your cluster.
 - **Supports TCP connections via GCP SSH Bastion (for databases)**
 - Automatic local port assignment (no collisions)
 - Single fixed entry port for HTTP/gRPC, dedicated ports for TCP
-- **Individual listener ports for gRPC services** (`overwrite_listen_ports`)
+- **Individual listener port for gRPC services** (`listener_port`)
 - Host-based routing (`<service>.localhost`)
 - Auto-reconnecting `port-forward` and SSH tunnels
 - kubectl-native UX (krew plugin friendly)
@@ -146,15 +146,13 @@ services:
     port_name: http
     protocol: http2  # Explicitly use HTTP/2
 
-  # gRPC Service with individual listener ports
+  # gRPC Service with individual listener port
   - kind: kubernetes
     host: grpc-api.localhost
     namespace: grpc
     service: grpc-api
     protocol: grpc
-    overwrite_listen_ports:  # Listen on specific ports instead of listener_port
-      - 50051
-      - 50052
+    listener_port: 50051  # Listen on specific port instead of global listener_port
 
   # Database via GCP SSH Bastion (TCP)
   - kind: tcp
@@ -176,8 +174,8 @@ services:
   - `http`: HTTP/1.1 (default for most REST APIs)
   - `http2`: HTTP/2 cleartext (h2c) for HTTP/2-capable services
   - `grpc`: gRPC (requires HTTP/2)
-- `overwrite_listen_ports`: (optional) List of ports for individual Envoy listeners
-  - When specified, the service listens on these ports instead of `listener_port`
+- `listener_port`: (optional) Port for individual Envoy listener
+  - When specified, the service listens on this port instead of global `listener_port`
   - Useful for gRPC clients that require specific ports (e.g., `grpcurl host:50051`)
 
 **For Database via SSH Bastion:**
@@ -245,7 +243,7 @@ By default, `/etc/hosts` is automatically updated, enabling simple hostname-base
 
 - HTTP: `curl http://billing-api.localhost/health`
 - gRPC: `grpcurl -plaintext users-api.localhost list`
-- gRPC (with `overwrite_listen_ports`): `grpcurl -plaintext grpc-api.localhost:50051 list`
+- gRPC (with `listener_port`): `grpcurl -plaintext grpc-api.localhost:50051 list`
 - **Database (TCP)**: `psql -h users-db.localhost -p 5432 -U myuser`
 
 When using port 80 (set `listener_port: 80` in config):

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1029,10 +1029,10 @@ listener_port: 80
 	}
 }
 
-// ========== OverwriteListenPorts関連テスト ==========
+// ========== ListenerPort関連テスト ==========
 
-func TestLoad_KubernetesService_WithOverwriteListenPorts_GRPC(t *testing.T) {
-	// gRPCサービスでoverwrite_listen_portsを指定（正常系）
+func TestLoad_KubernetesService_WithListenerPort_GRPC(t *testing.T) {
+	// gRPCサービスでlistener_portを指定（正常系）
 	content := `
 listener_port: 80
 services:
@@ -1042,8 +1042,7 @@ services:
     service: grpc-svc
     port_name: grpc
     protocol: grpc
-    overwrite_listen_ports:
-      - 50051
+    listener_port: 50051
 `
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
@@ -1064,54 +1063,13 @@ services:
 	if !ok {
 		t.Fatal("expected KubernetesService")
 	}
-	if len(k8sSvc.OverwriteListenPorts) != 1 || k8sSvc.OverwriteListenPorts[0] != 50051 {
-		t.Errorf("expected overwrite_listen_ports [50051], got %v", k8sSvc.OverwriteListenPorts)
+	if k8sSvc.ListenerPort != 50051 {
+		t.Errorf("expected listener_port 50051, got %d", k8sSvc.ListenerPort)
 	}
 }
 
-func TestLoad_KubernetesService_WithOverwriteListenPorts_Multiple(t *testing.T) {
-	// gRPCサービスで複数のoverwrite_listen_portsを指定（正常系）
-	content := `
-listener_port: 80
-services:
-  - kind: kubernetes
-    host: grpc.localhost
-    namespace: default
-    service: grpc-svc
-    protocol: grpc
-    overwrite_listen_ports:
-      - 50051
-      - 50052
-      - 50053
-`
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.yaml")
-	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg, err := Load(configPath)
-	if err != nil {
-		t.Fatalf("Load failed: %v", err)
-	}
-
-	k8sSvc, ok := cfg.Services[0].AsKubernetes()
-	if !ok {
-		t.Fatal("expected KubernetesService")
-	}
-	expectedPorts := []port.IndividualListenerPort{50051, 50052, 50053}
-	if len(k8sSvc.OverwriteListenPorts) != len(expectedPorts) {
-		t.Errorf("expected overwrite_listen_ports %v, got %v", expectedPorts, k8sSvc.OverwriteListenPorts)
-	}
-	for i, p := range expectedPorts {
-		if k8sSvc.OverwriteListenPorts[i] != p {
-			t.Errorf("expected overwrite_listen_ports[%d] = %d, got %d", i, p, k8sSvc.OverwriteListenPorts[i])
-		}
-	}
-}
-
-func TestLoad_KubernetesService_WithOverwriteListenPorts_HTTP2(t *testing.T) {
-	// http2サービスでoverwrite_listen_portsを指定（正常系）
+func TestLoad_KubernetesService_WithListenerPort_HTTP2(t *testing.T) {
+	// http2サービスでlistener_portを指定（正常系）
 	content := `
 listener_port: 80
 services:
@@ -1120,8 +1078,7 @@ services:
     namespace: default
     service: http2-svc
     protocol: http2
-    overwrite_listen_ports:
-      - 8443
+    listener_port: 8443
 `
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
@@ -1138,13 +1095,13 @@ services:
 	if !ok {
 		t.Fatal("expected KubernetesService")
 	}
-	if len(k8sSvc.OverwriteListenPorts) != 1 || k8sSvc.OverwriteListenPorts[0] != 8443 {
-		t.Errorf("expected overwrite_listen_ports [8443], got %v", k8sSvc.OverwriteListenPorts)
+	if k8sSvc.ListenerPort != 8443 {
+		t.Errorf("expected listener_port 8443, got %d", k8sSvc.ListenerPort)
 	}
 }
 
-func TestLoad_KubernetesService_WithOverwriteListenPorts_HTTP(t *testing.T) {
-	// httpサービスでoverwrite_listen_portsを指定（正常系）
+func TestLoad_KubernetesService_WithListenerPort_HTTP(t *testing.T) {
+	// httpサービスでlistener_portを指定（正常系）
 	content := `
 listener_port: 80
 services:
@@ -1153,8 +1110,7 @@ services:
     namespace: default
     service: http-svc
     protocol: http
-    overwrite_listen_ports:
-      - 8080
+    listener_port: 8080
 `
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
@@ -1171,12 +1127,12 @@ services:
 	if !ok {
 		t.Fatal("expected KubernetesService")
 	}
-	if len(k8sSvc.OverwriteListenPorts) != 1 || k8sSvc.OverwriteListenPorts[0] != 8080 {
-		t.Errorf("expected overwrite_listen_ports [8080], got %v", k8sSvc.OverwriteListenPorts)
+	if k8sSvc.ListenerPort != 8080 {
+		t.Errorf("expected listener_port 8080, got %d", k8sSvc.ListenerPort)
 	}
 }
 
-func TestLoad_KubernetesService_WithOverwriteListenPorts_InvalidRange(t *testing.T) {
+func TestLoad_KubernetesService_WithListenerPort_InvalidRange(t *testing.T) {
 	// 不正なポート範囲（65536）
 	content := `
 listener_port: 80
@@ -1186,9 +1142,7 @@ services:
     namespace: default
     service: grpc-svc
     protocol: grpc
-    overwrite_listen_ports:
-      - 50051
-      - 65536
+    listener_port: 65536
 `
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
@@ -1198,48 +1152,15 @@ services:
 
 	_, err := Load(configPath)
 	if err == nil {
-		t.Fatal("expected error for overwrite_listen_ports out of range, got nil")
+		t.Fatal("expected error for listener_port out of range, got nil")
 	}
-	if !containsString(err.Error(), "overwrite_listen_ports") {
-		t.Errorf("expected error containing 'overwrite_listen_ports', got '%s'", err.Error())
-	}
-}
-
-func TestLoad_KubernetesService_WithEmptyOverwriteListenPorts(t *testing.T) {
-	// overwrite_listen_ports = [] は省略と同じ（正常系、HTTPリスナーに統合）
-	content := `
-listener_port: 80
-services:
-  - kind: kubernetes
-    host: grpc.localhost
-    namespace: default
-    service: grpc-svc
-    protocol: grpc
-    overwrite_listen_ports: []
-`
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.yaml")
-	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg, err := Load(configPath)
-	if err != nil {
-		t.Fatalf("Load failed: %v", err)
-	}
-
-	k8sSvc, ok := cfg.Services[0].AsKubernetes()
-	if !ok {
-		t.Fatal("expected KubernetesService")
-	}
-	// 空配列は省略と同じ扱い
-	if len(k8sSvc.OverwriteListenPorts) != 0 {
-		t.Errorf("expected empty overwrite_listen_ports, got %v", k8sSvc.OverwriteListenPorts)
+	if !containsString(err.Error(), "listener_port") {
+		t.Errorf("expected error containing 'listener_port', got '%s'", err.Error())
 	}
 }
 
-func TestLoad_KubernetesService_WithoutOverwriteListenPorts(t *testing.T) {
-	// overwrite_listen_ports省略（従来動作）
+func TestLoad_KubernetesService_WithoutListenerPort(t *testing.T) {
+	// listener_port省略（従来動作）
 	content := `
 listener_port: 80
 services:
@@ -1264,13 +1185,13 @@ services:
 	if !ok {
 		t.Fatal("expected KubernetesService")
 	}
-	if len(k8sSvc.OverwriteListenPorts) != 0 {
-		t.Errorf("expected empty overwrite_listen_ports (omitted), got %v", k8sSvc.OverwriteListenPorts)
+	if k8sSvc.ListenerPort != 0 {
+		t.Errorf("expected listener_port 0 (omitted), got %d", k8sSvc.ListenerPort)
 	}
 }
 
-func TestLoad_KubernetesService_MultipleGRPCWithOverwriteListenPorts(t *testing.T) {
-	// 複数のgRPCサービスがそれぞれ異なるoverwrite_listen_portsを持つ
+func TestLoad_KubernetesService_MultipleGRPCWithListenerPort(t *testing.T) {
+	// 複数のgRPCサービスがそれぞれ異なるlistener_portを持つ
 	content := `
 listener_port: 80
 services:
@@ -1279,16 +1200,13 @@ services:
     namespace: default
     service: grpc1-svc
     protocol: grpc
-    overwrite_listen_ports:
-      - 50051
+    listener_port: 50051
   - kind: kubernetes
     host: grpc2.localhost
     namespace: default
     service: grpc2-svc
     protocol: grpc
-    overwrite_listen_ports:
-      - 50052
-      - 50053
+    listener_port: 50052
   - kind: kubernetes
     host: grpc3.localhost
     namespace: default
@@ -1310,30 +1228,30 @@ services:
 		t.Fatalf("expected 3 services, got %d", len(cfg.Services))
 	}
 
-	// 1番目: overwrite_listen_ports [50051]
+	// 1番目: listener_port 50051
 	grpc1, ok := cfg.Services[0].AsKubernetes()
 	if !ok {
 		t.Fatal("expected KubernetesService for first service")
 	}
-	if len(grpc1.OverwriteListenPorts) != 1 || grpc1.OverwriteListenPorts[0] != 50051 {
-		t.Errorf("expected overwrite_listen_ports [50051], got %v", grpc1.OverwriteListenPorts)
+	if grpc1.ListenerPort != 50051 {
+		t.Errorf("expected listener_port 50051, got %d", grpc1.ListenerPort)
 	}
 
-	// 2番目: overwrite_listen_ports [50052, 50053]
+	// 2番目: listener_port 50052
 	grpc2, ok := cfg.Services[1].AsKubernetes()
 	if !ok {
 		t.Fatal("expected KubernetesService for second service")
 	}
-	if len(grpc2.OverwriteListenPorts) != 2 || grpc2.OverwriteListenPorts[0] != 50052 || grpc2.OverwriteListenPorts[1] != 50053 {
-		t.Errorf("expected overwrite_listen_ports [50052, 50053], got %v", grpc2.OverwriteListenPorts)
+	if grpc2.ListenerPort != 50052 {
+		t.Errorf("expected listener_port 50052, got %d", grpc2.ListenerPort)
 	}
 
-	// 3番目: overwrite_listen_ports 省略（空）
+	// 3番目: listener_port 省略（0）
 	grpc3, ok := cfg.Services[2].AsKubernetes()
 	if !ok {
 		t.Fatal("expected KubernetesService for third service")
 	}
-	if len(grpc3.OverwriteListenPorts) != 0 {
-		t.Errorf("expected empty overwrite_listen_ports, got %v", grpc3.OverwriteListenPorts)
+	if grpc3.ListenerPort != 0 {
+		t.Errorf("expected listener_port 0, got %d", grpc3.ListenerPort)
 	}
 }

--- a/internal/dump/visitor.go
+++ b/internal/dump/visitor.go
@@ -73,7 +73,7 @@ func (v *DumpVisitor) VisitKubernetes(s *config.KubernetesService) error {
 	clusterName := sanitize(fmt.Sprintf("%s_%s_%d", s.Namespace, s.Service, remotePort))
 
 	builder := envoy.NewKubernetesServiceBuilder(
-		s.Host, s.Protocol, s.Namespace, s.Service, s.PortName, s.Port, s.OverwriteListenPorts,
+		s.Host, s.Protocol, s.Namespace, s.Service, s.PortName, s.Port, s.ListenerPort,
 	)
 
 	v.serviceConfigs = append(v.serviceConfigs, envoy.ServiceConfig{

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -9,7 +9,7 @@ func TestBuildConfig_HTTPOnly(t *testing.T) {
 	builder := NewKubernetesServiceBuilder(
 		"api.localhost", "http",
 		"default", "api", "http", 8080,
-		nil, // OverwriteListenPorts
+		0, // OverwriteListenPort
 	)
 	configs := []ServiceConfig{
 		{
@@ -106,7 +106,7 @@ func TestBuildConfig_MixedHTTPAndTCP(t *testing.T) {
 			Builder: NewKubernetesServiceBuilder(
 				"api.localhost", "http",
 				"default", "api", "http", 8080,
-				nil,
+				0,
 			),
 			ClusterName: "api_cluster",
 			LocalPort:   10001,
@@ -218,7 +218,7 @@ func TestBuildConfig_HTTPProtocol(t *testing.T) {
 	builder := NewKubernetesServiceBuilder(
 		"api.localhost", "http",
 		"default", "api", "http", 8080,
-		nil,
+		0,
 	)
 	configs := []ServiceConfig{
 		{
@@ -276,7 +276,7 @@ func TestBuildConfig_HTTP2Protocol(t *testing.T) {
 	builder := NewKubernetesServiceBuilder(
 		"api.localhost", "http2",
 		"default", "api", "http", 8080,
-		nil,
+		0,
 	)
 	configs := []ServiceConfig{
 		{
@@ -334,7 +334,7 @@ func TestBuildConfig_gRPCProtocol(t *testing.T) {
 	builder := NewKubernetesServiceBuilder(
 		"grpc.localhost", "grpc",
 		"default", "grpc-service", "grpc", 9090,
-		nil,
+		0,
 	)
 	configs := []ServiceConfig{
 		{
@@ -394,7 +394,7 @@ func TestBuildConfig_MixedProtocols(t *testing.T) {
 			Builder: NewKubernetesServiceBuilder(
 				"api.localhost", "http",
 				"default", "api", "http", 8080,
-				nil,
+				0,
 			),
 			ClusterName: "api_cluster",
 			LocalPort:   10001,
@@ -403,7 +403,7 @@ func TestBuildConfig_MixedProtocols(t *testing.T) {
 			Builder: NewKubernetesServiceBuilder(
 				"api2.localhost", "http2",
 				"default", "api2", "http", 8080,
-				nil,
+				0,
 			),
 			ClusterName: "api2_cluster",
 			LocalPort:   10002,
@@ -412,7 +412,7 @@ func TestBuildConfig_MixedProtocols(t *testing.T) {
 			Builder: NewKubernetesServiceBuilder(
 				"grpc.localhost", "grpc",
 				"default", "grpc-service", "grpc", 9090,
-				nil,
+				0,
 			),
 			ClusterName: "grpc_cluster",
 			LocalPort:   10003,

--- a/internal/log/summary_test.go
+++ b/internal/log/summary_test.go
@@ -160,7 +160,7 @@ func TestGenerateSummary_OverwriteListenPort(t *testing.T) {
 
 	result := GenerateSummary(services, 80)
 
-	// overwrite_listen_portsで指定されたポートが使われるべき
+	// listener_portで指定されたポートが使われるべき
 	if !strings.Contains(result, "http://special-api.localhost:9090") {
 		t.Errorf("missing overwritten listen port in summary:\n%s", result)
 	}

--- a/internal/port/port.go
+++ b/internal/port/port.go
@@ -24,8 +24,8 @@ type ServicePort int
 // TCPPort はTCP接続のポート番号（target_port, listen_port）
 type TCPPort int
 
-// IndividualListenerPort は個別リスナーのポート番号
-type IndividualListenerPort int
+// IndividualListenerPort は個別リスナーのポート番号（ListenerPortのエイリアス）
+type IndividualListenerPort = ListenerPort
 
 const (
 	minPort           = 1

--- a/internal/port/port_test.go
+++ b/internal/port/port_test.go
@@ -214,13 +214,13 @@ func TestValidatePorts(t *testing.T) {
 
 func TestValidatePorts_GenericType(t *testing.T) {
 	ports := []IndividualListenerPort{80, 443, 8080}
-	err := ValidatePorts(ports, "overwrite_listen_ports", "my-service")
+	err := ValidatePorts(ports, "listener_port", "my-service")
 	if err != nil {
 		t.Errorf("ValidatePorts() with IndividualListenerPort should succeed, got error: %v", err)
 	}
 
 	invalidPorts := []IndividualListenerPort{80, 0, 8080}
-	err = ValidatePorts(invalidPorts, "overwrite_listen_ports", "my-service")
+	err = ValidatePorts(invalidPorts, "listener_port", "my-service")
 	if err == nil {
 		t.Error("ValidatePorts() with invalid IndividualListenerPort should fail")
 	}

--- a/internal/run/visitor.go
+++ b/internal/run/visitor.go
@@ -81,7 +81,7 @@ func (v *RunVisitor) VisitKubernetes(s *config.KubernetesService) error {
 
 	// ビルダー構築
 	builder := envoy.NewKubernetesServiceBuilder(
-		s.Host, s.Protocol, s.Namespace, s.Service, s.PortName, s.Port, s.OverwriteListenPorts,
+		s.Host, s.Protocol, s.Namespace, s.Service, s.PortName, s.Port, s.ListenerPort,
 	)
 
 	v.logger.Debugf(
@@ -95,8 +95,8 @@ func (v *RunVisitor) VisitKubernetes(s *config.KubernetesService) error {
 
 	// ServiceSummaryを追加
 	var listenPort port.ListenerPort
-	if len(s.OverwriteListenPorts) > 0 {
-		listenPort = port.ListenerPort(s.OverwriteListenPorts[0])
+	if s.ListenerPort != 0 {
+		listenPort = s.ListenerPort
 	}
 	v.serviceSummaries = append(v.serviceSummaries, log.ServiceSummary{
 		Host:        s.Host,

--- a/internal/snapshot/mapping.go
+++ b/internal/snapshot/mapping.go
@@ -20,10 +20,9 @@ type PortForwardMapping struct {
 	TargetPort int    `yaml:"target_port,omitempty"`
 
 	// Common assigned ports
-	AssignedLocalPort     int    `yaml:"assigned_local_port"`
-	AssignedListenAddr    string `yaml:"assigned_listen_addr,omitempty"`    // TCPサービス用（loopback IP）
-	AssignedListenerPort  int    `yaml:"assigned_listener_port,omitempty"`  // TCPサービス用
-	AssignedListenerPorts []int  `yaml:"assigned_listener_ports,omitempty"` // OverwriteListenPorts用
+	AssignedLocalPort    int    `yaml:"assigned_local_port"`
+	AssignedListenAddr   string `yaml:"assigned_listen_addr,omitempty"`   // TCPサービス用（loopback IP）
+	AssignedListenerPort int    `yaml:"assigned_listener_port,omitempty"` // TCPサービス用 / 個別リスナーポート
 
 	// Envoy cluster reference
 	EnvoyClusterName string `yaml:"envoy_cluster_name"`
@@ -53,13 +52,9 @@ func BuildMappings(configs []envoy.ServiceConfig) PortForwardMappingSet {
 				EnvoyClusterName:   cfg.ClusterName,
 			}
 
-			// OverwriteListenPortsがある場合はリスナーポートも記録
-			if len(builder.OverwriteListenPorts) > 0 {
-				ports := make([]int, len(builder.OverwriteListenPorts))
-				for i, p := range builder.OverwriteListenPorts {
-					ports[i] = int(p)
-				}
-				mapping.AssignedListenerPorts = ports
+			// OverwriteListenPortがある場合はリスナーポートも記録
+			if builder.OverwriteListenPort != 0 {
+				mapping.AssignedListenerPort = int(builder.OverwriteListenPort)
 			}
 
 			mappings = append(mappings, mapping)

--- a/internal/snapshot/mapping_test.go
+++ b/internal/snapshot/mapping_test.go
@@ -142,7 +142,7 @@ func TestPortForwardMappingSet_YAML(t *testing.T) {
 func TestBuildMappings(t *testing.T) {
 	t.Run("kubernetes services", func(t *testing.T) {
 		builder := envoy.NewKubernetesServiceBuilder(
-			"api.localhost", "http", "default", "api", "http", 0, nil,
+			"api.localhost", "http", "default", "api", "http", 0, 0,
 		)
 		configs := []envoy.ServiceConfig{
 			{
@@ -170,10 +170,10 @@ func TestBuildMappings(t *testing.T) {
 		assertEqual(t, "default_api_8080", m.EnvoyClusterName)
 	})
 
-	t.Run("kubernetes services with overwrite_listen_ports", func(t *testing.T) {
+	t.Run("kubernetes services with listener_port", func(t *testing.T) {
 		builder := envoy.NewKubernetesServiceBuilder(
 			"grpc.localhost", "grpc", "default", "grpc-service", "grpc", 0,
-			[]port.IndividualListenerPort{8081, 8082},
+			port.IndividualListenerPort(8081),
 		)
 		configs := []envoy.ServiceConfig{
 			{
@@ -194,12 +194,8 @@ func TestBuildMappings(t *testing.T) {
 		assertEqual(t, "kubernetes", m.Kind)
 		assertEqual(t, "grpc.localhost", m.Host)
 		assertEqual(t, "grpc", m.Protocol)
-		// OverwriteListenPortsはAssignedListenerPortsに記録
-		if len(m.AssignedListenerPorts) != 2 {
-			t.Fatalf("expected 2 listener ports, got %d", len(m.AssignedListenerPorts))
-		}
-		assertEqual(t, 8081, m.AssignedListenerPorts[0])
-		assertEqual(t, 8082, m.AssignedListenerPorts[1])
+		// OverwriteListenPortはAssignedListenerPortに記録
+		assertEqual(t, 8081, m.AssignedListenerPort)
 	})
 
 	t.Run("tcp services", func(t *testing.T) {
@@ -234,7 +230,7 @@ func TestBuildMappings(t *testing.T) {
 
 	t.Run("mixed services", func(t *testing.T) {
 		k8sBuilder := envoy.NewKubernetesServiceBuilder(
-			"api.localhost", "http", "default", "api", "http", 0, nil,
+			"api.localhost", "http", "default", "api", "http", 0, 0,
 		)
 		tcpBuilder := envoy.NewTCPServiceBuilder(
 			"db.localhost", 5432, "127.0.0.2", "primary", "10.0.0.1", 5432,

--- a/testdata/envoy-snapshots/testdata/configs/grpc-with-listen-ports.yaml
+++ b/testdata/envoy-snapshots/testdata/configs/grpc-with-listen-ports.yaml
@@ -7,5 +7,4 @@ services:
     service: grpc-svc
     port_name: grpc
     protocol: grpc
-    overwrite_listen_ports:
-      - 50051
+    listener_port: 50051

--- a/testdata/envoy-snapshots/testdata/configs/multiple-grpc-listen-ports.yaml
+++ b/testdata/envoy-snapshots/testdata/configs/multiple-grpc-listen-ports.yaml
@@ -1,24 +1,21 @@
 listener_port: 80
 
 services:
-  # gRPCサービス1 - 複数ポートで待ち受け
+  # gRPCサービス1 - 個別リスナーポート
   - kind: kubernetes
     host: grpc1.localhost
     namespace: default
     service: grpc1-svc
     protocol: grpc
-    overwrite_listen_ports:
-      - 50051
-      - 50052
+    listener_port: 50051
 
-  # gRPCサービス2 - 個別ポート
+  # gRPCサービス2 - 個別リスナーポート
   - kind: kubernetes
     host: grpc2.localhost
     namespace: default
     service: grpc2-svc
     protocol: grpc
-    overwrite_listen_ports:
-      - 51051
+    listener_port: 51051
 
   # gRPCサービス3 - 従来動作（HTTPリスナー統合）
   - kind: kubernetes

--- a/testdata/envoy-snapshots/testdata/portforward-mappings/grpc-with-listen-ports-mapping.yaml
+++ b/testdata/envoy-snapshots/testdata/portforward-mappings/grpc-with-listen-ports-mapping.yaml
@@ -7,6 +7,5 @@ services:
       port_name: grpc
       resolved_remote_port: 50051
       assigned_local_port: 10000
-      assigned_listener_ports:
-        - 50051
+      assigned_listener_port: 50051
       envoy_cluster_name: default_grpc_svc_50051

--- a/testdata/envoy-snapshots/testdata/portforward-mappings/multiple-grpc-listen-ports-mapping.yaml
+++ b/testdata/envoy-snapshots/testdata/portforward-mappings/multiple-grpc-listen-ports-mapping.yaml
@@ -6,9 +6,7 @@ services:
       service: grpc1-svc
       resolved_remote_port: 50051
       assigned_local_port: 10000
-      assigned_listener_ports:
-        - 50051
-        - 50052
+      assigned_listener_port: 50051
       envoy_cluster_name: default_grpc1_svc_50051
     - kind: kubernetes
       host: grpc2.localhost
@@ -17,8 +15,7 @@ services:
       service: grpc2-svc
       resolved_remote_port: 51051
       assigned_local_port: 10001
-      assigned_listener_ports:
-        - 51051
+      assigned_listener_port: 51051
       envoy_cluster_name: default_grpc2_svc_51051
     - kind: kubernetes
       host: legacy-grpc.localhost

--- a/testdata/envoy-snapshots/testdata/snapshots/multiple-grpc-listen-ports.yaml
+++ b/testdata/envoy-snapshots/testdata/snapshots/multiple-grpc-listen-ports.yaml
@@ -155,38 +155,6 @@ static_resources:
         - address:
             socket_address:
                 address: 0.0.0.0
-                port_value: 50052
-          enable_reuse_port:
-            value: false
-          filter_chains:
-            - filters:
-                - name: envoy.filters.network.http_connection_manager
-                  typed_config:
-                    '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                    codec_type: AUTO
-                    http_filters:
-                        - name: envoy.filters.http.router
-                          typed_config:
-                            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                    http2_protocol_options: {}
-                    route_config:
-                        name: route_default_grpc1_svc_50051_50052
-                        virtual_hosts:
-                            - domains:
-                                - grpc1.localhost
-                                - grpc1.localhost:50052
-                              name: default_grpc1_svc_50051
-                              routes:
-                                - match:
-                                    prefix: /
-                                  route:
-                                    cluster: default_grpc1_svc_50051
-                                    timeout: 0s
-                    stat_prefix: ingress_default_grpc1_svc_50051_50052
-          name: listener_default_grpc1_svc_50051_50052
-        - address:
-            socket_address:
-                address: 0.0.0.0
                 port_value: 51051
           enable_reuse_port:
             value: false


### PR DESCRIPTION
## Summary

KubernetesServiceの`overwrite_listen_ports`（配列）を`listener_port`（単数）に変更し、設定を簡素化。

### 変更内容
- `OverwriteListenPorts []port.IndividualListenerPort` → `ListenerPort port.ListenerPort`に変更
- `IndividualListenerPort`型を`ListenerPort`のエイリアスに変更
- 複数ポート同時指定機能を削除

### 破壊的変更
```yaml
# Before
overwrite_listen_ports:
  - 50051
  - 50052

# After
listener_port: 50051
```

## Changes
- README.md
- internal/config/config.go
- internal/config/config_test.go
- internal/dump/visitor.go
- internal/envoy/config_test.go
- internal/envoy/kubernetes.go
- internal/envoy/kubernetes_test.go
- internal/log/summary_test.go
- internal/port/port.go
- internal/port/port_test.go
- internal/run/visitor.go
- internal/snapshot/mapping.go
- internal/snapshot/mapping_test.go
- testdata/envoy-snapshots/testdata/configs/grpc-with-listen-ports.yaml
- testdata/envoy-snapshots/testdata/configs/multiple-grpc-listen-ports.yaml
- testdata/envoy-snapshots/testdata/portforward-mappings/grpc-with-listen-ports-mapping.yaml
- testdata/envoy-snapshots/testdata/portforward-mappings/multiple-grpc-listen-ports-mapping.yaml
- testdata/envoy-snapshots/testdata/snapshots/grpc-with-listen-ports.yaml
- testdata/envoy-snapshots/testdata/snapshots/multiple-grpc-listen-ports.yaml