### PR TITLE
test: add gRPC E2E test using grpcurl

### DIFF
--- a/test/e2e/compose.yaml
+++ b/test/e2e/compose.yaml
@@ -35,7 +35,7 @@ services:
       - ./output:/output
       - ./fixtures/k8s:/manifests:ro
       - ./configs:/configs:ro
-    command: ["up", "-f", "/configs/http-only.yaml", "--no-edit-hosts"]
+    command: ["up", "-f", "/configs/http-and-grpc.yaml", "--no-edit-hosts"]
     networks:
       - e2e-network
     healthcheck:

--- a/test/e2e/configs/http-and-grpc.yaml
+++ b/test/e2e/configs/http-and-grpc.yaml
@@ -1,6 +1,13 @@
 listener_port: 18080
 services:
   - kind: kubernetes
+    host: http-test.localdomain
+    namespace: e2e-test
+    service: http-test-server
+    port_name: http
+    protocol: http
+
+  - kind: kubernetes
     host: grpc-test.localdomain
     namespace: e2e-test
     service: grpc-test-server

--- a/test/e2e/configs/http-only.yaml
+++ b/test/e2e/configs/http-only.yaml
@@ -1,8 +1,0 @@
-listener_port: 18080
-services:
-  - kind: kubernetes
-    host: http-test.localdomain
-    namespace: e2e-test
-    service: http-test-server
-    port_name: http
-    protocol: http

--- a/test/e2e/tests/run-all.sh
+++ b/test/e2e/tests/run-all.sh
@@ -31,4 +31,33 @@ else
 fi
 
 echo ""
+
+# gRPC テスト
+echo "--- Test: gRPC Routing ---"
+
+# grpcurlで -authority フラグを使用（HTTP Host headerと同等）
+# || true で exit code をキャプチャ（既存HTTPテストと同じパターン）
+grpc_response=$(grpcurl -plaintext \
+  -authority grpc-test.localdomain \
+  -d '{"name":"e2e-test"}' \
+  "${LOCALMESH_HOST}:${LOCALMESH_PORT}" \
+  helloworld.Greeter/SayHello 2>&1 || true)
+
+# grpcurlはエラー時にstderrに出力するので、"ERROR"を含むかチェック
+if echo "$grpc_response" | grep -qi "error\|failed\|refused"; then
+    echo "FAILED: gRPC routing"
+    echo "Response: ${grpc_response}"
+    exit 1
+fi
+
+# レスポンスに "Hello e2e-test" が含まれることを確認
+if echo "$grpc_response" | grep -q "Hello e2e-test"; then
+    echo "PASSED: gRPC routing"
+else
+    echo "FAILED: gRPC routing (unexpected response)"
+    echo "Response: ${grpc_response}"
+    exit 1
+fi
+
+echo ""
 echo "=== All tests passed ==="


### PR DESCRIPTION
## Summary

Add gRPC E2E test to verify that kubectl-localmesh correctly routes gRPC traffic via Envoy's virtual host mechanism. The test uses grpcurl with the `-authority` flag to simulate gRPC's `:authority` header for routing.

Consolidate separate config files (http-only.yaml, grpc-only.yaml) into a single http-and-grpc.yaml that tests both protocols.

## Changes
- test/e2e/compose.yaml
- test/e2e/configs/http-and-grpc.yaml
- test/e2e/configs/http-only.yaml
- test/e2e/tests/run-all.sh