### PR TITLE
feat: add JSON Schema for config validation and validate subcommand

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,8 +6,8 @@ yaml-files:
 extends: default
 
 ignore:
-  - 'testdata/envoy-snapshots/testdata/snapshots/*.yaml'
-  - 'testdata/envoy-snapshots/testdata/portforward-mappings/*.yaml'
+  - 'test/snapshot/testdata/snapshots/*.yaml'
+  - 'test/snapshot/testdata/portforward-mappings/*.yaml'
   - 'test/e2e/output/*.yaml'
 
 rules:

--- a/README.md
+++ b/README.md
@@ -205,9 +205,22 @@ To disable automatic `/etc/hosts` update:
 kubectl localmesh up -f services.yaml --no-edit-hosts
 ```
 
+### Validate configuration
+
+You can validate configuration files before running:
+
+```bash
+# Go-level validation (same checks as 'up')
+kubectl localmesh validate -f services.yaml
+
+# Additionally validate against JSON Schema (detects typos, unknown fields)
+kubectl localmesh validate -f services.yaml --strict
+```
+
 ### Subcommands
 
 - `up`: Start the local service mesh
+- `validate`: Validate configuration file
 - `dump-envoy-config`: Dump Envoy configuration to stdout
 - `down`: Stop the running mesh (planned)
 - `status`: Show mesh status (planned)
@@ -324,6 +337,32 @@ curl -H "Host: users-api.localhost" http://127.0.0.1:80/
 **Cleanup:**
 
 When you stop kubectl-localmesh (Ctrl+C), it automatically removes the managed entries from /etc/hosts.
+
+### JSON Schema for Editor Integration
+
+A JSON Schema file (`schemas/config.schema.json`) is provided for editor support (autocompletion and inline validation).
+
+**For files inside the repository:**
+
+```yaml
+# yaml-language-server: $schema=schemas/config.schema.json
+```
+
+**For files outside the repository** (e.g., your own `services.yaml`):
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/usadamasa/kubectl-local-mesh/main/schemas/config.schema.json
+```
+
+To pin to a specific version:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/usadamasa/kubectl-local-mesh/v0.3.0/schemas/config.schema.json
+```
+
+This works with VS Code (YAML extension), IntelliJ IDEA, and other editors that support `yaml-language-server`.
+
+The `--strict` flag in the `validate` subcommand uses this same schema to detect typos and unknown fields that Go-level validation does not catch.
 
 ### Advanced Usage
 
@@ -466,6 +505,7 @@ Roadmap ideas
 - krew distribution
 - ✅ Subcommands (`up` and `dump-envoy-config` implemented, `down` and `status` planned)
 - ✅ **GCP SSH Bastion support for database connections (TCP proxy)**
+- ✅ **JSON Schema for configuration validation and editor integration**
 - TLS support via local certificates
 - gRPC-web support
 - Envoy-less HTTP-only mode

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/usadamasa/kubectl-localmesh/internal/config"
+	"github.com/usadamasa/kubectl-localmesh/internal/validate"
+)
+
+type validateOptions struct {
+	configFile string
+	strict     bool
+}
+
+var validateOpts = &validateOptions{}
+
+var validateCmd = &cobra.Command{
+	Use:   "validate [config-file]",
+	Short: "Validate a configuration file",
+	Long: `Validate the configuration file syntax and structure.
+
+By default, runs Go-level validation (same as 'up' command).
+With --strict, additionally validates against JSON Schema (detects typos, unknown fields).
+
+Examples:
+  kubectl-localmesh validate -f services.yaml
+  kubectl-localmesh validate services.yaml
+  kubectl-localmesh validate -f services.yaml --strict`,
+	RunE: runValidate,
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+
+	validateCmd.Flags().StringVarP(&validateOpts.configFile, "config", "f", "", "config yaml path")
+	validateCmd.Flags().BoolVar(&validateOpts.strict, "strict", false, "additionally validate against JSON Schema (detects typos, unknown fields)")
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	// フラグが指定されていない場合、位置引数を使用
+	if validateOpts.configFile == "" && len(args) > 0 {
+		validateOpts.configFile = args[0]
+	}
+
+	if validateOpts.configFile == "" {
+		return fmt.Errorf("config file required: use -f or provide as argument")
+	}
+
+	// Go-level validation (config.Load)
+	_, err := config.Load(validateOpts.configFile)
+	if err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	// JSON Schema validation (optional)
+	if validateOpts.strict {
+		result, err := validate.ValidateSchemaFile(validateOpts.configFile)
+		if err != nil {
+			return fmt.Errorf("schema validation failed: %w", err)
+		}
+		if !result.OK() {
+			cmd.PrintErrln("Schema validation errors:")
+			for _, e := range result.Errors {
+				cmd.PrintErrln("  - " + e)
+			}
+			return fmt.Errorf("schema validation failed with %d error(s)", len(result.Errors))
+		}
+	}
+
+	cmd.Println("Configuration is valid.")
+	return nil
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func resetValidateOpts() {
+	validateOpts.configFile = ""
+	validateOpts.strict = false
+}
+
+func TestValidateCmd_ValidConfig(t *testing.T) {
+	resetValidateOpts()
+	content := `
+listener_port: 80
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{"validate", "-f", configPath})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateCmd_ValidConfigWithPositionalArg(t *testing.T) {
+	resetValidateOpts()
+	content := `
+listener_port: 80
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{"validate", configPath})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateCmd_MissingConfigFile(t *testing.T) {
+	resetValidateOpts()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"validate"})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for missing config file")
+	}
+}
+
+func TestValidateCmd_NonexistentFile(t *testing.T) {
+	resetValidateOpts()
+	cmd := rootCmd
+	cmd.SetArgs([]string{"validate", "-f", "/nonexistent/path.yaml"})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestValidateCmd_InvalidConfig(t *testing.T) {
+	resetValidateOpts()
+	// kindフィールドが欠落
+	content := `
+listener_port: 80
+services:
+  - host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{"validate", "-f", configPath})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for invalid config (missing kind)")
+	}
+}
+
+func TestValidateCmd_InvalidKindValue(t *testing.T) {
+	resetValidateOpts()
+	content := `
+listener_port: 80
+services:
+  - kind: invalid
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{"validate", "-f", configPath})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for invalid kind value")
+	}
+}
+
+func TestValidateCmd_StrictFlag_ValidConfig(t *testing.T) {
+	resetValidateOpts()
+	content := `
+listener_port: 80
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{"validate", "-f", configPath, "--strict"})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Errorf("expected no error with --strict flag, got: %v", err)
+	}
+}
+
+func TestValidateCmd_StrictFlag_InvalidConfig(t *testing.T) {
+	resetValidateOpts()
+	// additionalPropertiesに引っかかるフィールド
+	// config.Load()はunknown fieldをエラーにしないので、--strictフラグで検出される
+	content := `
+listener_port: 80
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+    unknown_field: value
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{"validate", "-f", configPath, "--strict"})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error with --strict flag for config with unknown field")
+	}
+}
+
+func TestValidateCmd_NoServices(t *testing.T) {
+	resetValidateOpts()
+	content := `
+listener_port: 80
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := rootCmd
+	cmd.SetArgs([]string{"validate", "-f", configPath})
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for config with no services")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/usadamasa/kubectl-localmesh
 go 1.25.5
 
 require (
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
@@ -70,6 +72,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,105 @@
+package validate
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/usadamasa/kubectl-localmesh/schemas"
+	"gopkg.in/yaml.v3"
+)
+
+// ValidationResult holds the results of schema validation.
+type ValidationResult struct {
+	Errors []string
+}
+
+// OK returns true if no validation errors were found.
+func (r *ValidationResult) OK() bool {
+	return len(r.Errors) == 0
+}
+
+// ValidateSchemaFile validates a YAML config file against the embedded JSON Schema.
+func ValidateSchemaFile(path string) (*ValidationResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	var doc any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	// Convert YAML-specific types to JSON-compatible types
+	doc = convertYAMLToJSON(doc)
+
+	return validateDocument(doc)
+}
+
+func validateDocument(doc any) (*ValidationResult, error) {
+	compiler := jsonschema.NewCompiler()
+
+	schemaDoc, err := jsonschema.UnmarshalJSON(strings.NewReader(schemas.ConfigSchema))
+	if err != nil {
+		return nil, fmt.Errorf("parsing embedded schema: %w", err)
+	}
+
+	if err := compiler.AddResource("config.schema.json", schemaDoc); err != nil {
+		return nil, fmt.Errorf("loading schema: %w", err)
+	}
+
+	schema, err := compiler.Compile("config.schema.json")
+	if err != nil {
+		return nil, fmt.Errorf("compiling schema: %w", err)
+	}
+
+	result := &ValidationResult{}
+	if err := schema.Validate(doc); err != nil {
+		if ve, ok := err.(*jsonschema.ValidationError); ok {
+			collectErrors(ve, result)
+		} else {
+			result.Errors = append(result.Errors, err.Error())
+		}
+	}
+
+	return result, nil
+}
+
+func collectErrors(ve *jsonschema.ValidationError, result *ValidationResult) {
+	if len(ve.Causes) == 0 {
+		msg := ve.Error()
+		result.Errors = append(result.Errors, msg)
+		return
+	}
+	for _, cause := range ve.Causes {
+		collectErrors(cause, result)
+	}
+}
+
+// convertYAMLToJSON converts YAML-specific types to JSON-compatible types.
+// yaml.v3 decodes integer values as int, but JSON Schema validation expects
+// float64 for numeric values (matching encoding/json conventions).
+func convertYAMLToJSON(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(val))
+		for k, v := range val {
+			result[k] = convertYAMLToJSON(v)
+		}
+		return result
+	case []any:
+		result := make([]any, len(val))
+		for i, v := range val {
+			result[i] = convertYAMLToJSON(v)
+		}
+		return result
+	case int:
+		return float64(val)
+	case int64:
+		return float64(val)
+	default:
+		return val
+	}
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,603 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateSchema_ValidKubernetesService(t *testing.T) {
+	content := `
+listener_port: 80
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    port_name: http
+    protocol: http
+`
+	result := validateYAMLContent(t, content)
+	if !result.OK() {
+		t.Errorf("expected valid config, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateSchema_ValidTCPService(t *testing.T) {
+	content := `
+listener_port: 80
+ssh_bastions:
+  primary:
+    instance: bastion-1
+    zone: asia-northeast1-a
+    project: test-project
+services:
+  - kind: tcp
+    host: db.localhost
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 5432
+`
+	result := validateYAMLContent(t, content)
+	if !result.OK() {
+		t.Errorf("expected valid config, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateSchema_ValidMixedServices(t *testing.T) {
+	content := `
+listener_port: 80
+ssh_bastions:
+  primary:
+    instance: bastion-1
+    zone: asia-northeast1-a
+services:
+  - kind: kubernetes
+    host: api.localhost
+    namespace: default
+    service: api
+    protocol: grpc
+  - kind: tcp
+    host: db.localhost
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 5432
+`
+	result := validateYAMLContent(t, content)
+	if !result.OK() {
+		t.Errorf("expected valid config, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateSchema_ValidWithListenerPort(t *testing.T) {
+	content := `
+listener_port: 80
+services:
+  - kind: kubernetes
+    host: grpc.localhost
+    namespace: default
+    service: grpc-svc
+    protocol: grpc
+    listener_port: 50051
+`
+	result := validateYAMLContent(t, content)
+	if !result.OK() {
+		t.Errorf("expected valid config, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateSchema_ValidWithoutListenerPort(t *testing.T) {
+	// listener_port省略（デフォルト値が使われる）
+	content := `
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`
+	result := validateYAMLContent(t, content)
+	if !result.OK() {
+		t.Errorf("expected valid config, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateSchema_ValidWithPort(t *testing.T) {
+	content := `
+listener_port: 80
+services:
+  - kind: kubernetes
+    host: admin.localhost
+    namespace: admin
+    service: admin-web
+    port: 8080
+    protocol: http
+`
+	result := validateYAMLContent(t, content)
+	if !result.OK() {
+		t.Errorf("expected valid config, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateSchema_ValidTCPWithListenPort(t *testing.T) {
+	content := `
+listener_port: 80
+ssh_bastions:
+  primary:
+    instance: bastion-1
+    zone: asia-northeast1-a
+services:
+  - kind: tcp
+    host: db.localhost
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 5432
+    listen_port: 15432
+`
+	result := validateYAMLContent(t, content)
+	if !result.OK() {
+		t.Errorf("expected valid config, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateSchema_MissingServices(t *testing.T) {
+	content := `
+listener_port: 80
+`
+	result := validateYAMLContent(t, content)
+	if result.OK() {
+		t.Error("expected validation error for missing services")
+	}
+	assertContainsError(t, result, "services")
+}
+
+func TestValidateSchema_EmptyServices(t *testing.T) {
+	content := `
+listener_port: 80
+services: []
+`
+	result := validateYAMLContent(t, content)
+	if result.OK() {
+		t.Error("expected validation error for empty services")
+	}
+	assertContainsError(t, result, "services")
+}
+
+func TestValidateSchema_MissingKind(t *testing.T) {
+	content := `
+listener_port: 80
+services:
+  - host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`
+	result := validateYAMLContent(t, content)
+	if result.OK() {
+		t.Error("expected validation error for missing kind")
+	}
+}
+
+func TestValidateSchema_InvalidKind(t *testing.T) {
+	content := `
+listener_port: 80
+services:
+  - kind: invalid
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`
+	result := validateYAMLContent(t, content)
+	if result.OK() {
+		t.Error("expected validation error for invalid kind")
+	}
+}
+
+func TestValidateSchema_MissingRequiredKubernetesFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		errMsg  string
+	}{
+		{
+			name: "missing host",
+			content: `
+services:
+  - kind: kubernetes
+    namespace: test
+    service: test-svc
+    protocol: http
+`,
+			errMsg: "host",
+		},
+		{
+			name: "missing namespace",
+			content: `
+services:
+  - kind: kubernetes
+    host: test.localhost
+    service: test-svc
+    protocol: http
+`,
+			errMsg: "namespace",
+		},
+		{
+			name: "missing service",
+			content: `
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    protocol: http
+`,
+			errMsg: "service",
+		},
+		{
+			name: "missing protocol",
+			content: `
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+`,
+			errMsg: "protocol",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateYAMLContent(t, tt.content)
+			if result.OK() {
+				t.Errorf("expected validation error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidateSchema_InvalidProtocol(t *testing.T) {
+	content := `
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: invalid
+`
+	result := validateYAMLContent(t, content)
+	if result.OK() {
+		t.Error("expected validation error for invalid protocol")
+	}
+}
+
+func TestValidateSchema_MissingRequiredTCPFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "missing host",
+			content: `
+ssh_bastions:
+  primary:
+    instance: bastion-1
+    zone: zone-a
+services:
+  - kind: tcp
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 5432
+`,
+		},
+		{
+			name: "missing ssh_bastion",
+			content: `
+services:
+  - kind: tcp
+    host: db.localhost
+    target_host: 10.0.0.1
+    target_port: 5432
+`,
+		},
+		{
+			name: "missing target_host",
+			content: `
+ssh_bastions:
+  primary:
+    instance: bastion-1
+    zone: zone-a
+services:
+  - kind: tcp
+    host: db.localhost
+    ssh_bastion: primary
+    target_port: 5432
+`,
+		},
+		{
+			name: "missing target_port",
+			content: `
+ssh_bastions:
+  primary:
+    instance: bastion-1
+    zone: zone-a
+services:
+  - kind: tcp
+    host: db.localhost
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateYAMLContent(t, tt.content)
+			if result.OK() {
+				t.Errorf("expected validation error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidateSchema_UnknownField(t *testing.T) {
+	content := `
+listener_port: 80
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+    unknown_field: value
+`
+	result := validateYAMLContent(t, content)
+	if result.OK() {
+		t.Error("expected validation error for unknown field")
+	}
+}
+
+func TestValidateSchema_UnknownTopLevelField(t *testing.T) {
+	content := `
+listener_port: 80
+unknown_top: value
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`
+	result := validateYAMLContent(t, content)
+	if result.OK() {
+		t.Error("expected validation error for unknown top-level field")
+	}
+}
+
+func TestValidateSchema_UnknownSSHBastionField(t *testing.T) {
+	content := `
+listener_port: 80
+ssh_bastions:
+  primary:
+    instance: bastion-1
+    zone: zone-a
+    unknown_field: value
+services:
+  - kind: tcp
+    host: db.localhost
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 5432
+`
+	result := validateYAMLContent(t, content)
+	if result.OK() {
+		t.Error("expected validation error for unknown SSH bastion field")
+	}
+}
+
+func TestValidateSchema_InvalidPortRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "listener_port too high",
+			content: `
+listener_port: 65536
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`,
+		},
+		{
+			name: "listener_port zero",
+			content: `
+listener_port: 0
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: http
+`,
+		},
+		{
+			name: "target_port too high",
+			content: `
+ssh_bastions:
+  primary:
+    instance: bastion-1
+    zone: zone-a
+services:
+  - kind: tcp
+    host: db.localhost
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 70000
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateYAMLContent(t, tt.content)
+			if result.OK() {
+				t.Errorf("expected validation error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidateSchema_SSHBastionMissingRequired(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "missing instance",
+			content: `
+ssh_bastions:
+  primary:
+    zone: zone-a
+services:
+  - kind: tcp
+    host: db.localhost
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 5432
+`,
+		},
+		{
+			name: "missing zone",
+			content: `
+ssh_bastions:
+  primary:
+    instance: bastion-1
+services:
+  - kind: tcp
+    host: db.localhost
+    ssh_bastion: primary
+    target_host: 10.0.0.1
+    target_port: 5432
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateYAMLContent(t, tt.content)
+			if result.OK() {
+				t.Errorf("expected validation error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidateSchema_AllProtocols(t *testing.T) {
+	protocols := []string{"http", "http2", "grpc"}
+	for _, protocol := range protocols {
+		t.Run(protocol, func(t *testing.T) {
+			content := `
+services:
+  - kind: kubernetes
+    host: test.localhost
+    namespace: test
+    service: test-svc
+    protocol: ` + protocol + `
+`
+			result := validateYAMLContent(t, content)
+			if !result.OK() {
+				t.Errorf("expected valid config for protocol %s, got errors: %v", protocol, result.Errors)
+			}
+		})
+	}
+}
+
+func TestValidateSchema_ExistingTestDataConfigs(t *testing.T) {
+	configDir := filepath.Join("..", "..", "test", "snapshot", "testdata", "configs")
+	entries, err := os.ReadDir(configDir)
+	if err != nil {
+		t.Skipf("test data directory not found: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		t.Run(entry.Name(), func(t *testing.T) {
+			path := filepath.Join(configDir, entry.Name())
+			result, err := ValidateSchemaFile(path)
+			if err != nil {
+				t.Fatalf("ValidateSchemaFile failed: %v", err)
+			}
+			if !result.OK() {
+				t.Errorf("expected valid config for %s, got errors: %v", entry.Name(), result.Errors)
+			}
+		})
+	}
+}
+
+func TestValidateSchemaFile_NonexistentFile(t *testing.T) {
+	_, err := ValidateSchemaFile("/nonexistent/path.yaml")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestValidateSchemaFile_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "invalid.yaml")
+	if err := os.WriteFile(path, []byte(":\n  :\n    - :\n      invalid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ValidateSchemaFile(path)
+	// Invalid YAML may cause unmarshal error or schema validation error
+	// Either is acceptable
+	if err != nil {
+		return // unmarshal error is fine
+	}
+}
+
+func TestValidationResult_OK(t *testing.T) {
+	result := &ValidationResult{}
+	if !result.OK() {
+		t.Error("expected OK() to return true for empty result")
+	}
+
+	result.Errors = append(result.Errors, "error")
+	if result.OK() {
+		t.Error("expected OK() to return false when errors exist")
+	}
+}
+
+// Helper functions
+
+func validateYAMLContent(t *testing.T, content string) *ValidationResult {
+	t.Helper()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ValidateSchemaFile(path)
+	if err != nil {
+		t.Fatalf("ValidateSchemaFile failed: %v", err)
+	}
+	return result
+}
+
+func assertContainsError(t *testing.T, result *ValidationResult, substr string) {
+	t.Helper()
+	for _, e := range result.Errors {
+		if strings.Contains(e, substr) {
+			return
+		}
+	}
+	t.Errorf("expected error containing %q, got: %v", substr, result.Errors)
+}

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/usadamasa/kubectl-localmesh/schemas/config.schema.json",
+  "title": "kubectl-localmesh configuration",
+  "description": "Configuration file for kubectl-localmesh local service mesh",
+  "type": "object",
+  "properties": {
+    "listener_port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "default": 80,
+      "description": "Envoy main listener port for HTTP/gRPC services"
+    },
+    "ssh_bastions": {
+      "type": "object",
+      "description": "GCP SSH bastion definitions for TCP proxy connections",
+      "additionalProperties": {
+        "$ref": "#/$defs/SSHBastion"
+      }
+    },
+    "services": {
+      "type": "array",
+      "description": "List of services to route",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/Service"
+      }
+    }
+  },
+  "required": ["services"],
+  "additionalProperties": false,
+  "$defs": {
+    "SSHBastion": {
+      "type": "object",
+      "description": "GCP SSH bastion configuration",
+      "properties": {
+        "instance": {
+          "type": "string",
+          "description": "GCP Compute Instance name"
+        },
+        "zone": {
+          "type": "string",
+          "description": "GCP zone"
+        },
+        "project": {
+          "type": "string",
+          "description": "GCP project ID (optional, uses gcloud config default)"
+        }
+      },
+      "required": ["instance", "zone"],
+      "additionalProperties": false
+    },
+    "Service": {
+      "oneOf": [
+        { "$ref": "#/$defs/KubernetesService" },
+        { "$ref": "#/$defs/TCPService" }
+      ]
+    },
+    "KubernetesService": {
+      "type": "object",
+      "description": "Kubernetes service routed via kubectl port-forward",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["kubernetes"]
+        },
+        "host": {
+          "type": "string",
+          "description": "Local hostname for accessing this service (e.g., users-api.localhost)"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Kubernetes namespace"
+        },
+        "service": {
+          "type": "string",
+          "description": "Kubernetes Service name"
+        },
+        "port_name": {
+          "type": "string",
+          "description": "Service port name (for multi-port Services)"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Explicit port number"
+        },
+        "protocol": {
+          "type": "string",
+          "enum": ["http", "http2", "grpc"],
+          "description": "Protocol type"
+        },
+        "listener_port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Individual listener port (overrides main listener_port)"
+        }
+      },
+      "required": ["kind", "host", "namespace", "service", "protocol"],
+      "additionalProperties": false
+    },
+    "TCPService": {
+      "type": "object",
+      "description": "TCP service routed via GCP SSH bastion tunnel",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["tcp"]
+        },
+        "host": {
+          "type": "string",
+          "description": "Local hostname for accessing this service"
+        },
+        "ssh_bastion": {
+          "type": "string",
+          "description": "Reference to ssh_bastions map key"
+        },
+        "target_host": {
+          "type": "string",
+          "description": "Private IP of the target (e.g., Cloud SQL)"
+        },
+        "target_port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Target port number"
+        },
+        "listen_port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Local listen port (defaults to target_port)"
+        }
+      },
+      "required": ["kind", "host", "ssh_bastion", "target_host", "target_port"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/embed.go
+++ b/schemas/embed.go
@@ -1,0 +1,6 @@
+package schemas
+
+import _ "embed"
+
+//go:embed config.schema.json
+var ConfigSchema string

--- a/schemas/embed_test.go
+++ b/schemas/embed_test.go
@@ -1,0 +1,215 @@
+package schemas
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func TestConfigSchema_ValidJSON(t *testing.T) {
+	// スキーマファイルがvalid JSONであることを確認
+	var doc any
+	if err := json.Unmarshal([]byte(ConfigSchema), &doc); err != nil {
+		t.Fatalf("config.schema.json is not valid JSON: %v", err)
+	}
+}
+
+func TestConfigSchema_Compilable(t *testing.T) {
+	// スキーマがjsonschemaライブラリでコンパイルできることを確認
+	compiler := jsonschema.NewCompiler()
+
+	schemaDoc, err := jsonschema.UnmarshalJSON(strings.NewReader(ConfigSchema))
+	if err != nil {
+		t.Fatalf("failed to unmarshal schema: %v", err)
+	}
+
+	if err := compiler.AddResource("config.schema.json", schemaDoc); err != nil {
+		t.Fatalf("failed to add schema resource: %v", err)
+	}
+
+	_, err = compiler.Compile("config.schema.json")
+	if err != nil {
+		t.Fatalf("config.schema.json failed to compile: %v", err)
+	}
+}
+
+func TestConfigSchema_HasRequiredStructure(t *testing.T) {
+	// スキーマに必要な構造が含まれていることを確認
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(ConfigSchema), &schema); err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	// $schema フィールド
+	schemaVersion, ok := schema["$schema"].(string)
+	if !ok {
+		t.Fatal("missing $schema field")
+	}
+	if schemaVersion != "https://json-schema.org/draft/2020-12/schema" {
+		t.Errorf("expected Draft 2020-12 schema, got %s", schemaVersion)
+	}
+
+	// type: object
+	if schema["type"] != "object" {
+		t.Errorf("expected root type 'object', got %v", schema["type"])
+	}
+
+	// required: services
+	required, ok := schema["required"].([]any)
+	if !ok {
+		t.Fatal("missing required field")
+	}
+	found := false
+	for _, r := range required {
+		if r == "services" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("'services' should be in required fields")
+	}
+
+	// $defs should contain Service, KubernetesService, TCPService, SSHBastion
+	defs, ok := schema["$defs"].(map[string]any)
+	if !ok {
+		t.Fatal("missing $defs")
+	}
+
+	expectedDefs := []string{"Service", "KubernetesService", "TCPService", "SSHBastion"}
+	for _, name := range expectedDefs {
+		if _, ok := defs[name]; !ok {
+			t.Errorf("missing $defs/%s", name)
+		}
+	}
+}
+
+func TestConfigSchema_ServiceOneOf(t *testing.T) {
+	// Service定義がoneOfでKubernetesServiceとTCPServiceを持つことを確認
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(ConfigSchema), &schema); err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	defs := schema["$defs"].(map[string]any)
+	service := defs["Service"].(map[string]any)
+
+	oneOf, ok := service["oneOf"].([]any)
+	if !ok {
+		t.Fatal("Service should have oneOf")
+	}
+	if len(oneOf) != 2 {
+		t.Errorf("Service oneOf should have 2 items, got %d", len(oneOf))
+	}
+}
+
+func TestConfigSchema_KubernetesServiceKindEnum(t *testing.T) {
+	// KubernetesServiceのkindがenum ["kubernetes"]であることを確認
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(ConfigSchema), &schema); err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	defs := schema["$defs"].(map[string]any)
+	k8s := defs["KubernetesService"].(map[string]any)
+	props := k8s["properties"].(map[string]any)
+	kind := props["kind"].(map[string]any)
+
+	enum, ok := kind["enum"].([]any)
+	if !ok || len(enum) != 1 {
+		t.Fatalf("KubernetesService kind should have enum with 1 value, got %v", kind["enum"])
+	}
+	if enum[0] != "kubernetes" {
+		t.Errorf("KubernetesService kind enum should be ['kubernetes'], got %v", enum)
+	}
+}
+
+func TestConfigSchema_TCPServiceKindEnum(t *testing.T) {
+	// TCPServiceのkindがenum ["tcp"]であることを確認
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(ConfigSchema), &schema); err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	defs := schema["$defs"].(map[string]any)
+	tcp := defs["TCPService"].(map[string]any)
+	props := tcp["properties"].(map[string]any)
+	kind := props["kind"].(map[string]any)
+
+	enum, ok := kind["enum"].([]any)
+	if !ok || len(enum) != 1 {
+		t.Fatalf("TCPService kind should have enum with 1 value, got %v", kind["enum"])
+	}
+	if enum[0] != "tcp" {
+		t.Errorf("TCPService kind enum should be ['tcp'], got %v", enum)
+	}
+}
+
+func TestConfigSchema_AdditionalPropertiesFalse(t *testing.T) {
+	// 全objectにadditionalProperties: falseが設定されていることを確認
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(ConfigSchema), &schema); err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	// Root object
+	if schema["additionalProperties"] != false {
+		t.Error("root object should have additionalProperties: false")
+	}
+
+	defs := schema["$defs"].(map[string]any)
+
+	// KubernetesService
+	k8s := defs["KubernetesService"].(map[string]any)
+	if k8s["additionalProperties"] != false {
+		t.Error("KubernetesService should have additionalProperties: false")
+	}
+
+	// TCPService
+	tcp := defs["TCPService"].(map[string]any)
+	if tcp["additionalProperties"] != false {
+		t.Error("TCPService should have additionalProperties: false")
+	}
+
+	// SSHBastion
+	bastion := defs["SSHBastion"].(map[string]any)
+	if bastion["additionalProperties"] != false {
+		t.Error("SSHBastion should have additionalProperties: false")
+	}
+}
+
+func TestConfigSchema_ProtocolEnum(t *testing.T) {
+	// protocolフィールドのenum値を確認
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(ConfigSchema), &schema); err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	defs := schema["$defs"].(map[string]any)
+	k8s := defs["KubernetesService"].(map[string]any)
+	props := k8s["properties"].(map[string]any)
+	protocol := props["protocol"].(map[string]any)
+
+	enum, ok := protocol["enum"].([]any)
+	if !ok {
+		t.Fatal("protocol should have enum")
+	}
+
+	expected := map[string]bool{"http": true, "http2": true, "grpc": true}
+	for _, v := range enum {
+		s, ok := v.(string)
+		if !ok {
+			t.Errorf("enum value should be string, got %T", v)
+			continue
+		}
+		if !expected[s] {
+			t.Errorf("unexpected protocol enum value: %s", s)
+		}
+		delete(expected, s)
+	}
+	for missing := range expected {
+		t.Errorf("missing protocol enum value: %s", missing)
+	}
+}

--- a/service.example.yaml
+++ b/service.example.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=schemas/config.schema.json
 listener_port: 80
 
 # Optional: GCP SSH Bastions for database connections

--- a/test/e2e/configs/http-and-grpc.yaml
+++ b/test/e2e/configs/http-and-grpc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../schemas/config.schema.json
 listener_port: 18080
 services:
   - kind: kubernetes

--- a/test/snapshot/testdata/configs/grpc-with-listen-ports.yaml
+++ b/test/snapshot/testdata/configs/grpc-with-listen-ports.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 
 services:

--- a/test/snapshot/testdata/configs/http-only.yaml
+++ b/test/snapshot/testdata/configs/http-only.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 services:
   - kind: kubernetes

--- a/test/snapshot/testdata/configs/mixed-http-tcp.yaml
+++ b/test/snapshot/testdata/configs/mixed-http-tcp.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 ssh_bastions:
   primary:

--- a/test/snapshot/testdata/configs/mixed-protocols.yaml
+++ b/test/snapshot/testdata/configs/mixed-protocols.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 services:
   - kind: kubernetes

--- a/test/snapshot/testdata/configs/multiple-grpc-listen-ports.yaml
+++ b/test/snapshot/testdata/configs/multiple-grpc-listen-ports.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 
 services:

--- a/test/snapshot/testdata/configs/multiple-tcp-same-port.yaml
+++ b/test/snapshot/testdata/configs/multiple-tcp-same-port.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 ssh_bastions:
   primary:

--- a/test/snapshot/testdata/configs/protocol-grpc.yaml
+++ b/test/snapshot/testdata/configs/protocol-grpc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 services:
   - kind: kubernetes

--- a/test/snapshot/testdata/configs/protocol-http.yaml
+++ b/test/snapshot/testdata/configs/protocol-http.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 services:
   - kind: kubernetes

--- a/test/snapshot/testdata/configs/protocol-http2.yaml
+++ b/test/snapshot/testdata/configs/protocol-http2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 services:
   - kind: kubernetes

--- a/test/snapshot/testdata/configs/tcp-only.yaml
+++ b/test/snapshot/testdata/configs/tcp-only.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../../../schemas/config.schema.json
 listener_port: 80
 ssh_bastions:
   primary:


### PR DESCRIPTION
## Summary
- JSON Schema (Draft 2020-12) で設定ファイルの構造を定義し、エディタでの入力補完・構文チェックを可能に
- `validate` サブコマンドを追加し、`up` 実行前に設定ファイルの妥当性を事前確認可能に
- `--schema` フラグで JSON Schema に対する検証も実行可能（タイポ検出など）
- `.yamllint.yaml` の ignore パスを #73 のスナップショット移動に合わせて修正

## Test plan
- [x] `task test` が全パッケージでパス
- [x] `task lint` (yamllint + golangci-lint) がクリア
- [ ] `./bin/kubectl-localmesh validate -f service.example.yaml` が成功
- [ ] `./bin/kubectl-localmesh validate -f service.example.yaml --schema` が成功
- [ ] 不正な設定ファイルでエラーが出ること
- [ ] IntelliJ / VS Code で `service.example.yaml` のスキーマ補完が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)