### PR TITLE
feat: add multi-cluster support with per-service cluster override

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 
 type Config struct {
 	ListenerPort port.ListenerPort      `yaml:"listener_port"`
+	Cluster      string                 `yaml:"cluster,omitempty"`
 	SSHBastions  map[string]*SSHBastion `yaml:"ssh_bastions,omitempty"`
 	Services     []ServiceDefinition    `yaml:"services"`
 }
@@ -44,6 +45,7 @@ type KubernetesService struct {
 	Port         port.ServicePort  `yaml:"port,omitempty"`
 	Protocol     string            `yaml:"protocol"`                // http|http2|grpc
 	ListenerPort port.ListenerPort `yaml:"listener_port,omitempty"` // 個別リスナーポート（指定時はHTTPリスナーを上書き）
+	Cluster      string            `yaml:"cluster,omitempty"`       // kubeconfig cluster name（オーバーライド用）
 }
 
 // TCPService はGCP SSH Bastion経由のTCP接続を表現
@@ -224,6 +226,9 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
+	// グローバルClusterのトリム
+	cfg.Cluster = strings.TrimSpace(cfg.Cluster)
+
 	// デフォルト値設定
 	if cfg.ListenerPort == 0 {
 		cfg.ListenerPort = 80
@@ -288,6 +293,7 @@ func trimServiceFields(svc Service) {
 		s.Service = strings.TrimSpace(s.Service)
 		s.PortName = strings.TrimSpace(s.PortName)
 		s.Protocol = strings.TrimSpace(s.Protocol)
+		s.Cluster = strings.TrimSpace(s.Cluster)
 	case *TCPService:
 		s.Host = strings.TrimSpace(s.Host)
 		s.SSHBastion = strings.TrimSpace(s.SSHBastion)

--- a/internal/dump/visitor_test.go
+++ b/internal/dump/visitor_test.go
@@ -11,7 +11,7 @@ func TestDumpVisitor_Creation(t *testing.T) {
 	// DumpVisitorの生成テスト
 	ctx := context.Background()
 
-	visitor := NewDumpVisitor(ctx, nil, nil)
+	visitor := NewDumpVisitor(ctx, "", nil)
 
 	if visitor == nil {
 		t.Fatal("expected visitor to be created")
@@ -26,7 +26,7 @@ func TestDumpVisitor_VisitTCP(t *testing.T) {
 	// DumpVisitorのVisitTCPテスト（モック不要）
 	ctx := context.Background()
 
-	visitor := NewDumpVisitor(ctx, nil, nil)
+	visitor := NewDumpVisitor(ctx, "", nil)
 	visitor.SetIndex(0)
 
 	svc := &config.TCPService{

--- a/internal/envoy/config_test.go
+++ b/internal/envoy/config_test.go
@@ -10,6 +10,7 @@ func TestBuildConfig_HTTPOnly(t *testing.T) {
 		"api.localhost", "http",
 		"default", "api", "http", 8080,
 		0, // OverwriteListenPort
+		"",
 	)
 	configs := []ServiceConfig{
 		{
@@ -107,6 +108,7 @@ func TestBuildConfig_MixedHTTPAndTCP(t *testing.T) {
 				"api.localhost", "http",
 				"default", "api", "http", 8080,
 				0,
+				"",
 			),
 			ClusterName: "api_cluster",
 			LocalPort:   10001,
@@ -219,6 +221,7 @@ func TestBuildConfig_HTTPProtocol(t *testing.T) {
 		"api.localhost", "http",
 		"default", "api", "http", 8080,
 		0,
+		"",
 	)
 	configs := []ServiceConfig{
 		{
@@ -277,6 +280,7 @@ func TestBuildConfig_HTTP2Protocol(t *testing.T) {
 		"api.localhost", "http2",
 		"default", "api", "http", 8080,
 		0,
+		"",
 	)
 	configs := []ServiceConfig{
 		{
@@ -335,6 +339,7 @@ func TestBuildConfig_gRPCProtocol(t *testing.T) {
 		"grpc.localhost", "grpc",
 		"default", "grpc-service", "grpc", 9090,
 		0,
+		"",
 	)
 	configs := []ServiceConfig{
 		{
@@ -395,6 +400,7 @@ func TestBuildConfig_MixedProtocols(t *testing.T) {
 				"api.localhost", "http",
 				"default", "api", "http", 8080,
 				0,
+				"",
 			),
 			ClusterName: "api_cluster",
 			LocalPort:   10001,
@@ -404,6 +410,7 @@ func TestBuildConfig_MixedProtocols(t *testing.T) {
 				"api2.localhost", "http2",
 				"default", "api2", "http", 8080,
 				0,
+				"",
 			),
 			ClusterName: "api2_cluster",
 			LocalPort:   10002,
@@ -413,6 +420,7 @@ func TestBuildConfig_MixedProtocols(t *testing.T) {
 				"grpc.localhost", "grpc",
 				"default", "grpc-service", "grpc", 9090,
 				0,
+				"",
 			),
 			ClusterName: "grpc_cluster",
 			LocalPort:   10003,

--- a/internal/envoy/kubernetes.go
+++ b/internal/envoy/kubernetes.go
@@ -16,10 +16,11 @@ type KubernetesServiceBuilder struct {
 	ServiceName string
 	PortName    string
 	Port        port.ServicePort
+	Cluster     string
 }
 
 // NewKubernetesServiceBuilder はKubernetesServiceBuilderを生成
-func NewKubernetesServiceBuilder(host, protocol, namespace, serviceName, portName string, p port.ServicePort, listenerPort port.IndividualListenerPort) *KubernetesServiceBuilder {
+func NewKubernetesServiceBuilder(host, protocol, namespace, serviceName, portName string, p port.ServicePort, listenerPort port.IndividualListenerPort, cluster string) *KubernetesServiceBuilder {
 	if protocol == "" {
 		protocol = "http" // デフォルトHTTP/1.1
 	}
@@ -31,6 +32,7 @@ func NewKubernetesServiceBuilder(host, protocol, namespace, serviceName, portNam
 		ServiceName:         serviceName,
 		PortName:            portName,
 		Port:                p,
+		Cluster:             cluster,
 	}
 }
 

--- a/internal/envoy/kubernetes_test.go
+++ b/internal/envoy/kubernetes_test.go
@@ -12,6 +12,7 @@ func TestKubernetesServiceBuilder_Build_HTTPRoute(t *testing.T) {
 		"api.localhost", "http",
 		"default", "api", "http", 8080,
 		0, // OverwriteListenPort
+		"",
 	)
 
 	result := builder.Build("api_cluster", 10001, 80)
@@ -39,6 +40,7 @@ func TestKubernetesServiceBuilder_Build_WithOverwriteListenPort(t *testing.T) {
 		"grpc.localhost", "grpc",
 		"default", "grpc-service", "grpc", 50051,
 		port.IndividualListenerPort(50051),
+		"",
 	)
 
 	result := builder.Build("grpc_cluster", 10001, 80)
@@ -75,6 +77,7 @@ func TestKubernetesServiceBuilder_Build_HTTP_WithOverwriteListenPort(t *testing.
 		"http.localhost", "http",
 		"default", "http-service", "http", 8080,
 		port.IndividualListenerPort(8080),
+		"",
 	)
 
 	result := builder.Build("http_cluster", 10001, 80)
@@ -105,6 +108,7 @@ func TestKubernetesServiceBuilder_Build_gRPC_WithOverwriteListenPort(t *testing.
 		"grpc.localhost", "grpc",
 		"default", "grpc-service", "grpc", 50051,
 		port.IndividualListenerPort(50051),
+		"",
 	)
 
 	result := builder.Build("grpc_cluster", 10001, 80)
@@ -129,6 +133,7 @@ func TestKubernetesServiceBuilder_GetHost(t *testing.T) {
 		"test.localhost", "http",
 		"default", "test", "http", 8080,
 		0,
+		"",
 	)
 
 	if builder.GetHost() != "test.localhost" {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -10,16 +10,15 @@ import (
 // It follows the same discovery order as kubectl:
 // 1. $KUBECONFIG environment variable
 // 2. ~/.kube/config
-// Uses the current-context from the kubeconfig.
-func NewClient() (*kubernetes.Clientset, *rest.Config, error) {
-	// kubeconfigのロードルール
-	// clientcmd.NewDefaultClientConfigLoadingRules() は以下の順序で検索:
-	// 1. $KUBECONFIG環境変数で指定されたパス
-	// 2. ~/.kube/config（デフォルト）
+// If cluster is non-empty, it overrides the cluster in the current-context
+// (equivalent to kubectl --cluster flag).
+func NewClient(cluster string) (*kubernetes.Clientset, *rest.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 
-	// current-contextを使用してRESTConfigを作成
 	configOverrides := &clientcmd.ConfigOverrides{}
+	if cluster != "" {
+		configOverrides.Context.Cluster = cluster
+	}
 
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		loadingRules,

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -6,18 +6,22 @@ import (
 	"testing"
 )
 
-func TestNewClient_ValidKubeconfig(t *testing.T) {
-	// 一時ディレクトリ作成（テスト終了時に自動削除）
-	tmpDir := t.TempDir()
-
-	// 最小限の有効なkubeconfigファイル作成
-	kubeconfigContent := `apiVersion: v1
+// multiClusterKubeconfig は複数クラスタを含むテスト用kubeconfig
+const multiClusterKubeconfig = `apiVersion: v1
 kind: Config
 clusters:
 - cluster:
     server: https://127.0.0.1:6443
     insecure-skip-tls-verify: true
   name: test-cluster
+- cluster:
+    server: https://10.0.0.1:6443
+    insecure-skip-tls-verify: true
+  name: staging-cluster
+- cluster:
+    server: https://10.0.0.2:6443
+    insecure-skip-tls-verify: true
+  name: prod-cluster
 contexts:
 - context:
     cluster: test-cluster
@@ -30,8 +34,12 @@ users:
     token: test-token
 `
 
+func TestNewClient_ValidKubeconfig(t *testing.T) {
+	// 一時ディレクトリ作成（テスト終了時に自動削除）
+	tmpDir := t.TempDir()
+
 	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
-	err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0600)
+	err := os.WriteFile(kubeconfigPath, []byte(multiClusterKubeconfig), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,8 +47,8 @@ users:
 	// 環境変数を設定（テスト終了時に自動復元）
 	t.Setenv("KUBECONFIG", kubeconfigPath)
 
-	// テスト実行
-	clientset, restConfig, err := NewClient()
+	// テスト実行（空文字列 = current-contextのclusterを使用）
+	clientset, restConfig, err := NewClient("")
 
 	// アサーション
 	if err != nil {
@@ -53,9 +61,60 @@ users:
 		t.Fatal("expected restConfig to be non-nil")
 	}
 
-	// restConfigの基本的な検証
+	// restConfigの基本的な検証（current-contextはtest-cluster → 127.0.0.1:6443）
 	if restConfig.Host != "https://127.0.0.1:6443" {
 		t.Errorf("expected host 'https://127.0.0.1:6443', got %q", restConfig.Host)
+	}
+}
+
+func TestNewClient_WithCluster(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+	if err := os.WriteFile(kubeconfigPath, []byte(multiClusterKubeconfig), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("KUBECONFIG", kubeconfigPath)
+
+	// staging-clusterを明示的に指定
+	clientset, restConfig, err := NewClient("staging-cluster")
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if clientset == nil {
+		t.Fatal("expected clientset to be non-nil")
+	}
+	if restConfig == nil {
+		t.Fatal("expected restConfig to be non-nil")
+	}
+
+	// staging-clusterのサーバーに接続すること
+	if restConfig.Host != "https://10.0.0.1:6443" {
+		t.Errorf("expected host 'https://10.0.0.1:6443', got %q", restConfig.Host)
+	}
+}
+
+func TestNewClient_EmptyCluster(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+	if err := os.WriteFile(kubeconfigPath, []byte(multiClusterKubeconfig), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("KUBECONFIG", kubeconfigPath)
+
+	// 空文字列 = current-contextのcluster（test-cluster）を使用
+	_, restConfig, err := NewClient("")
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if restConfig.Host != "https://127.0.0.1:6443" {
+		t.Errorf("expected host 'https://127.0.0.1:6443' (current-context cluster), got %q", restConfig.Host)
 	}
 }
 
@@ -71,7 +130,7 @@ func TestNewClient_InvalidKubeconfig(t *testing.T) {
 
 	t.Setenv("KUBECONFIG", invalidKubeconfigPath)
 
-	_, _, err = NewClient()
+	_, _, err = NewClient("")
 	if err == nil {
 		t.Fatal("expected error for invalid kubeconfig, got nil")
 	}
@@ -85,7 +144,7 @@ func TestNewClient_NoKubeconfig(t *testing.T) {
 	t.Setenv("KUBECONFIG", nonExistentPath)
 	t.Setenv("HOME", tmpDir) // ~/.kube/configも存在しないようにする
 
-	_, _, err := NewClient()
+	_, _, err := NewClient("")
 	if err == nil {
 		t.Fatal("expected error for non-existent kubeconfig, got nil")
 	}

--- a/internal/run/visitor_test.go
+++ b/internal/run/visitor_test.go
@@ -13,7 +13,7 @@ func TestRunVisitor_Creation(t *testing.T) {
 	ctx := context.Background()
 	cfg := &config.Config{}
 
-	visitor := NewRunVisitor(ctx, cfg, nil, nil, log.New("info"))
+	visitor := NewRunVisitor(ctx, cfg, log.New("info"))
 
 	if visitor == nil {
 		t.Fatal("expected visitor to be created")

--- a/internal/snapshot/mapping.go
+++ b/internal/snapshot/mapping.go
@@ -12,6 +12,7 @@ type PortForwardMapping struct {
 	Namespace          string `yaml:"namespace,omitempty"`
 	Service            string `yaml:"service,omitempty"`
 	PortName           string `yaml:"port_name,omitempty"`
+	Cluster            string `yaml:"cluster,omitempty"`
 	ResolvedRemotePort int    `yaml:"resolved_remote_port,omitempty"`
 
 	// TCP service fields
@@ -47,6 +48,7 @@ func BuildMappings(configs []envoy.ServiceConfig) PortForwardMappingSet {
 				Namespace:          builder.Namespace,
 				Service:            builder.ServiceName,
 				PortName:           builder.PortName,
+				Cluster:            builder.Cluster,
 				ResolvedRemotePort: int(cfg.ResolvedRemotePort),
 				AssignedLocalPort:  int(cfg.LocalPort),
 				EnvoyClusterName:   cfg.ClusterName,

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -12,6 +12,10 @@
       "default": 80,
       "description": "Envoy main listener port for HTTP/gRPC services"
     },
+    "cluster": {
+      "type": "string",
+      "description": "Default kubeconfig cluster name for all Kubernetes services (can be overridden per service)"
+    },
     "ssh_bastions": {
       "type": "object",
       "description": "GCP SSH bastion definitions for TCP proxy connections",
@@ -97,6 +101,10 @@
           "minimum": 1,
           "maximum": 65535,
           "description": "Individual listener port (overrides main listener_port)"
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Kubeconfig cluster name (overrides global cluster setting)"
         }
       },
       "required": ["kind", "host", "namespace", "service", "protocol"],

--- a/test/snapshot/testdata/configs/multi-cluster-services.yaml
+++ b/test/snapshot/testdata/configs/multi-cluster-services.yaml
@@ -1,0 +1,25 @@
+cluster: gke_myproject_asia-northeast1_staging
+listener_port: 80
+services:
+  - kind: kubernetes
+    host: users-api.localhost
+    namespace: users
+    service: users-api
+    port_name: grpc
+    protocol: grpc
+    # グローバルcluster継承 → gke_myproject_asia-northeast1_staging
+  - kind: kubernetes
+    host: admin.localhost
+    namespace: admin
+    service: admin-web
+    port_name: http
+    protocol: http
+    cluster: gke_myproject_asia-northeast1_prod
+    # サービス単位オーバーライド → gke_myproject_asia-northeast1_prod
+  - kind: kubernetes
+    host: api.localhost
+    namespace: default
+    service: api
+    port_name: http
+    protocol: http
+    # グローバルcluster継承 → gke_myproject_asia-northeast1_staging

--- a/test/snapshot/testdata/mocks/multi-cluster-services-mocks.yaml
+++ b/test/snapshot/testdata/mocks/multi-cluster-services-mocks.yaml
@@ -1,0 +1,13 @@
+mocks:
+  - namespace: users
+    service: users-api
+    port_name: grpc
+    resolved_port: 9090
+  - namespace: admin
+    service: admin-web
+    port_name: http
+    resolved_port: 8080
+  - namespace: default
+    service: api
+    port_name: http
+    resolved_port: 8080

--- a/test/snapshot/testdata/portforward-mappings/multi-cluster-services-mapping.yaml
+++ b/test/snapshot/testdata/portforward-mappings/multi-cluster-services-mapping.yaml
@@ -1,0 +1,29 @@
+services:
+    - kind: kubernetes
+      host: users-api.localhost
+      protocol: grpc
+      namespace: users
+      service: users-api
+      port_name: grpc
+      resolved_remote_port: 9090
+      assigned_local_port: 10000
+      envoy_cluster_name: users_users_api_9090
+    - kind: kubernetes
+      host: admin.localhost
+      protocol: http
+      namespace: admin
+      service: admin-web
+      port_name: http
+      cluster: gke_myproject_asia-northeast1_prod
+      resolved_remote_port: 8080
+      assigned_local_port: 10001
+      envoy_cluster_name: admin_admin_web_8080
+    - kind: kubernetes
+      host: api.localhost
+      protocol: http
+      namespace: default
+      service: api
+      port_name: http
+      resolved_remote_port: 8080
+      assigned_local_port: 10002
+      envoy_cluster_name: default_api_8080

--- a/test/snapshot/testdata/snapshots/multi-cluster-services.yaml
+++ b/test/snapshot/testdata/snapshots/multi-cluster-services.yaml
@@ -1,0 +1,115 @@
+overload_manager:
+    refresh_interval:
+        nanos: 250000000
+        seconds: 0
+    resource_monitors:
+        - name: envoy.resource_monitors.global_downstream_max_connections
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+            max_active_downstream_connections: 5000
+static_resources:
+    clusters:
+        - connect_timeout: 1s
+          load_assignment:
+            cluster_name: users_users_api_9090
+            endpoints:
+                - lb_endpoints:
+                    - endpoint:
+                        address:
+                            socket_address:
+                                address: 127.0.0.1
+                                port_value: 10000
+          name: users_users_api_9090
+          type: STATIC
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+                explicit_http_config:
+                    http2_protocol_options: {}
+        - connect_timeout: 1s
+          load_assignment:
+            cluster_name: admin_admin_web_8080
+            endpoints:
+                - lb_endpoints:
+                    - endpoint:
+                        address:
+                            socket_address:
+                                address: 127.0.0.1
+                                port_value: 10001
+          name: admin_admin_web_8080
+          type: STATIC
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+                explicit_http_config:
+                    http_protocol_options: {}
+        - connect_timeout: 1s
+          load_assignment:
+            cluster_name: default_api_8080
+            endpoints:
+                - lb_endpoints:
+                    - endpoint:
+                        address:
+                            socket_address:
+                                address: 127.0.0.1
+                                port_value: 10002
+          name: default_api_8080
+          type: STATIC
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+                explicit_http_config:
+                    http_protocol_options: {}
+    listeners:
+        - address:
+            socket_address:
+                address: 0.0.0.0
+                port_value: 80
+          enable_reuse_port:
+            value: false
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    codec_type: AUTO
+                    http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                    http2_protocol_options: {}
+                    route_config:
+                        name: local_route
+                        virtual_hosts:
+                            - domains:
+                                - users-api.localhost
+                                - users-api.localhost:80
+                              name: users_users_api_9090
+                              routes:
+                                - match:
+                                    prefix: /
+                                  route:
+                                    cluster: users_users_api_9090
+                                    timeout: 0s
+                            - domains:
+                                - admin.localhost
+                                - admin.localhost:80
+                              name: admin_admin_web_8080
+                              routes:
+                                - match:
+                                    prefix: /
+                                  route:
+                                    cluster: admin_admin_web_8080
+                                    timeout: 0s
+                            - domains:
+                                - api.localhost
+                                - api.localhost:80
+                              name: default_api_8080
+                              routes:
+                                - match:
+                                    prefix: /
+                                  route:
+                                    cluster: default_api_8080
+                                    timeout: 0s
+                    stat_prefix: ingress_http
+          name: listener_http


### PR DESCRIPTION
## Summary

- 設定ファイルにグローバル`cluster`フィールドとKubernetesサービス単位の`cluster`オーバーライドを追加
- `NewClient`がclusterパラメータを受け取り、`kubectl --cluster`相当のオーバーライドを実現
- `DumpVisitor`/`RunVisitor`で共有clientをクラスタ単位のlazy初期化キャッシュに置き換え
- `KubernetesServiceBuilder`と`PortForwardMapping`に`Cluster`フィールドを追加し、マッピング出力に反映
- JSON Schemaにclusterフィールド定義を追加
- 複数クラスタのスナップショットテスト（グローバル継承・サービス単位オーバーライド・未指定の3パターン）を追加

## Test plan

- [x] `task test` で全ユニットテスト通過
- [x] `task lint` でlintエラーなし
- [x] `task build && test/snapshot/scripts/run-snapshots.sh` でスナップショットテスト全11ケース通過（既存10 + 新規1）
- [x] 生成されたマッピング出力で`cluster`フィールドが正しく表示されることを確認
- [x] TCPサービスに`cluster`指定した場合、JSON Schema検証でエラーになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)