### PR TITLE
feat: add version command support and install task

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,13 @@ builds:
     goos:
       - linux
       - darwin
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
 
 archives:
   - formats: [tar.gz]

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -27,6 +27,22 @@ tasks:
       - yamllint -c .yamllint.yaml .
       - golangci-lint run
 
+  install:
+    desc: Install the binary to $GOBIN
+    vars:
+      GIT_VERSION:
+        sh: git describe --tags --always --dirty 2>/dev/null || echo "dev"
+      GIT_COMMIT:
+        sh: git rev-parse --short HEAD 2>/dev/null || echo "none"
+      BUILD_DATE:
+        sh: date -u +"%Y-%m-%dT%H:%M:%SZ"
+    cmds:
+      - go clean -i .
+      - |
+        go install -trimpath -v \
+          -ldflags="-X main.version={{.GIT_VERSION}} -X main.commit={{.GIT_COMMIT}} -X main.date={{.BUILD_DATE}}" \
+          .
+
   format:
     desc: Format code
     cmds:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,11 @@ func init() {
 	)
 }
 
+func SetVersion(v, c, d string) {
+	rootCmd.Version = v
+	rootCmd.SetVersionTemplate("{{.Name}} version " + v + " (" + d + ", " + c + ")\n")
+}
+
 func Execute() error {
 	return rootCmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,14 @@ import (
 	"github.com/usadamasa/kubectl-localmesh/cmd"
 )
 
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
+	cmd.SetVersion(version, commit, date)
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- `kubectl-localmesh --version` でバージョン情報（gitタグ、コミットハッシュ、ビルド日時）を表示できるようにした
- `task install` でldflags付きの `go install` を実行し、$GOBINにバイナリをインストールできるようにした
- `.goreleaser.yaml` にも同じldflags設定を追加し、リリースビルドでもバージョン情報が埋め込まれるようにした

## Test plan

- [x] `task install` を実行し、$GOBINにバイナリが配置されることを確認
- [x] `kubectl-localmesh --version` でバージョン情報が正しく表示されることを確認
- [x] `task test` が全て通ることを確認
- [x] `task lint` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)