### PR TITLE
feat: add ReadBuildInfo fallback for go install version output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/usadamasa/kubectl-localmesh/internal/version"
 )
 
 var globalLogLevel string
@@ -26,9 +27,9 @@ func init() {
 	)
 }
 
-func SetVersion(v, c, d string) {
-	rootCmd.Version = v
-	rootCmd.SetVersionTemplate("{{.Name}} version " + v + " (" + d + ", " + c + ")\n")
+func SetVersion(info version.Info) {
+	rootCmd.Version = info.Version
+	rootCmd.SetVersionTemplate("{{.Name}} version " + info.DisplayString() + "\n")
 }
 
 func Execute() error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/usadamasa/kubectl-localmesh/internal/version"
 )
 
 func TestRootCommand(t *testing.T) {
@@ -13,6 +15,50 @@ func TestRootCommand(t *testing.T) {
 			t.Errorf("Execute() returned error: %v", err)
 		}
 	})
+}
+
+func TestSetVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		info            version.Info
+		wantVersion     string
+		wantInTemplate  string
+		wantNotTemplate string
+	}{
+		{
+			name:            "全フィールド設定",
+			info:            version.Info{Version: "v1.2.3", Commit: "abc1234", Date: "2024-01-01T00:00:00Z"},
+			wantVersion:     "v1.2.3",
+			wantInTemplate:  "v1.2.3 (commit: abc1234, built: 2024-01-01T00:00:00Z)",
+			wantNotTemplate: "",
+		},
+		{
+			name:            "デフォルト値で括弧なし",
+			info:            version.Info{Version: "dev", Commit: "none", Date: "unknown"},
+			wantVersion:     "dev",
+			wantInTemplate:  "dev",
+			wantNotTemplate: "(",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetVersion(tt.info)
+
+			if rootCmd.Version != tt.wantVersion {
+				t.Errorf("rootCmd.Version = %q, want %q", rootCmd.Version, tt.wantVersion)
+			}
+
+			// VersionTemplateの内容を検証
+			tmpl := rootCmd.VersionTemplate()
+			if !strings.Contains(tmpl, tt.wantInTemplate) {
+				t.Errorf("VersionTemplate() = %q, want to contain %q", tmpl, tt.wantInTemplate)
+			}
+			if tt.wantNotTemplate != "" && strings.Contains(tmpl, tt.wantNotTemplate) {
+				t.Errorf("VersionTemplate() = %q, should not contain %q", tmpl, tt.wantNotTemplate)
+			}
+		})
+	}
 }
 
 func TestRootCommand_GlobalFlags(t *testing.T) {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,60 @@
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Info はバージョン情報を保持する構造体
+type Info struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
+// DisplayString はバージョン情報を表示用文字列にフォーマットする。
+// commit/dateがデフォルト値の場合は括弧ごと省略する。
+func (i Info) DisplayString() string {
+	var parts []string
+	if i.Commit != "none" {
+		parts = append(parts, "commit: "+i.Commit)
+	}
+	if i.Date != "unknown" {
+		parts = append(parts, "built: "+i.Date)
+	}
+	if len(parts) == 0 {
+		return i.Version
+	}
+	return i.Version + " (" + strings.Join(parts, ", ") + ")"
+}
+
+// テスト用に差し替え可能
+var readBuildInfo = debug.ReadBuildInfo
+
+// Resolve はldflagsの値を優先しつつ、未設定時はruntime/debug.ReadBuildInfoでフォールバックする。
+func Resolve(ldVersion, ldCommit, ldDate string) Info {
+	if ldVersion != "dev" {
+		return Info{Version: ldVersion, Commit: ldCommit, Date: ldDate}
+	}
+
+	info := Info{Version: ldVersion, Commit: ldCommit, Date: ldDate}
+
+	bi, ok := readBuildInfo()
+	if !ok {
+		return info
+	}
+
+	if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		info.Version = bi.Main.Version
+	}
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			info.Commit = s.Value
+		case "vcs.time":
+			info.Date = s.Value
+		}
+	}
+
+	return info
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,146 @@
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+func TestDisplayString(t *testing.T) {
+	tests := []struct {
+		name string
+		info Info
+		want string
+	}{
+		{
+			name: "all fields set",
+			info: Info{Version: "v1.2.3", Commit: "abc1234", Date: "2024-01-01T00:00:00Z"},
+			want: "v1.2.3 (commit: abc1234, built: 2024-01-01T00:00:00Z)",
+		},
+		{
+			name: "default commit and date",
+			info: Info{Version: "v0.0.2", Commit: "none", Date: "unknown"},
+			want: "v0.0.2",
+		},
+		{
+			name: "only commit available",
+			info: Info{Version: "v0.0.2", Commit: "abc1234", Date: "unknown"},
+			want: "v0.0.2 (commit: abc1234)",
+		},
+		{
+			name: "only date available",
+			info: Info{Version: "v0.0.2", Commit: "none", Date: "2024-01-01T00:00:00Z"},
+			want: "v0.0.2 (built: 2024-01-01T00:00:00Z)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.info.DisplayString()
+			if got != tt.want {
+				t.Errorf("DisplayString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDisplayString_NoParentheses(t *testing.T) {
+	info := Info{Version: "v0.0.2", Commit: "none", Date: "unknown"}
+	got := info.DisplayString()
+	if strings.Contains(got, "(") || strings.Contains(got, ")") {
+		t.Errorf("DisplayString() = %q, should not contain parentheses", got)
+	}
+}
+
+func TestResolve_LdflagsSet(t *testing.T) {
+	info := Resolve("v1.2.3", "abc1234", "2024-01-01T00:00:00Z")
+
+	if info.Version != "v1.2.3" {
+		t.Errorf("Version = %q, want %q", info.Version, "v1.2.3")
+	}
+	if info.Commit != "abc1234" {
+		t.Errorf("Commit = %q, want %q", info.Commit, "abc1234")
+	}
+	if info.Date != "2024-01-01T00:00:00Z" {
+		t.Errorf("Date = %q, want %q", info.Date, "2024-01-01T00:00:00Z")
+	}
+}
+
+func TestResolve_DevWithBuildInfo(t *testing.T) {
+	original := readBuildInfo
+	t.Cleanup(func() { readBuildInfo = original })
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Version: "v0.3.0",
+			},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "def5678abcdef5678abcdef5678abcdef5678abc"},
+				{Key: "vcs.time", Value: "2024-06-15T12:00:00Z"},
+			},
+		}, true
+	}
+
+	info := Resolve("dev", "none", "unknown")
+
+	if info.Version != "v0.3.0" {
+		t.Errorf("Version = %q, want %q", info.Version, "v0.3.0")
+	}
+	if info.Commit != "def5678abcdef5678abcdef5678abcdef5678abc" {
+		t.Errorf("Commit = %q, want %q", info.Commit, "def5678abcdef5678abcdef5678abcdef5678abc")
+	}
+	if info.Date != "2024-06-15T12:00:00Z" {
+		t.Errorf("Date = %q, want %q", info.Date, "2024-06-15T12:00:00Z")
+	}
+}
+
+func TestResolve_DevWithBuildInfoDevel(t *testing.T) {
+	original := readBuildInfo
+	t.Cleanup(func() { readBuildInfo = original })
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Version: "(devel)",
+			},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "aaa1111"},
+				{Key: "vcs.time", Value: "2024-03-01T09:00:00Z"},
+			},
+		}, true
+	}
+
+	info := Resolve("dev", "none", "unknown")
+
+	if info.Version != "dev" {
+		t.Errorf("Version = %q, want %q", info.Version, "dev")
+	}
+	if info.Commit != "aaa1111" {
+		t.Errorf("Commit = %q, want %q", info.Commit, "aaa1111")
+	}
+	if info.Date != "2024-03-01T09:00:00Z" {
+		t.Errorf("Date = %q, want %q", info.Date, "2024-03-01T09:00:00Z")
+	}
+}
+
+func TestResolve_DevWithoutBuildInfo(t *testing.T) {
+	original := readBuildInfo
+	t.Cleanup(func() { readBuildInfo = original })
+
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return nil, false
+	}
+
+	info := Resolve("dev", "none", "unknown")
+
+	if info.Version != "dev" {
+		t.Errorf("Version = %q, want %q", info.Version, "dev")
+	}
+	if info.Commit != "none" {
+		t.Errorf("Commit = %q, want %q", info.Commit, "none")
+	}
+	if info.Date != "unknown" {
+		t.Errorf("Date = %q, want %q", info.Date, "unknown")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/usadamasa/kubectl-localmesh/cmd"
+	versionpkg "github.com/usadamasa/kubectl-localmesh/internal/version"
 )
 
 var (
@@ -14,7 +15,8 @@ var (
 )
 
 func main() {
-	cmd.SetVersion(version, commit, date)
+	info := versionpkg.Resolve(version, commit, date)
+	cmd.SetVersion(info)
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- `internal/version` パッケージを新規追加し、`runtime/debug.ReadBuildInfo()` によるバージョン情報のフォールバックを実装
- `go install @latest` 等でインストールしたバイナリでもモジュールバージョンやVCS情報が `--version` に表示されるように改善
- ldflags設定済み（GoReleaser / `task install`）の場合は従来通りの動作を維持

## Test plan
- [x] `TestDisplayString` - 全フィールド設定 / デフォルト値 / commitのみ / dateのみ
- [x] `TestDisplayString_NoParentheses` - デフォルト値で括弧が出ないことを確認
- [x] `TestResolve_LdflagsSet` - ldflags設定済みならそのまま返す
- [x] `TestResolve_DevWithBuildInfo` - dev時にReadBuildInfoからバージョン/VCS情報を取得
- [x] `TestResolve_DevWithBuildInfoDevel` - バージョンが `(devel)` ならdevのまま
- [x] `TestResolve_DevWithoutBuildInfo` - BuildInfo取得失敗時はデフォルト値
- [x] `TestSetVersion` - `version.Info` を渡して rootCmd の Version と VersionTemplate が正しく設定されることを検証
- [x] `internal/version` パッケージのテストカバレッジ100%
- [x] `task test` 全パス
- [x] `task lint` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)