### PR TITLE
fix: update golangci-lint to v2.10.1 to resolve go1.26 panic

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -6,5 +6,5 @@ registries:
     ref: v4.448.1  # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: go-task/task@v3.46.4
-  - name: golangci/golangci-lint@v2.7.2
+  - name: golangci/golangci-lint@v2.10.1
   - name: goreleaser/goreleaser@v2.13.2

--- a/internal/hosts/validate.go
+++ b/internal/hosts/validate.go
@@ -29,7 +29,7 @@ func (e *hostsFileCorruptedError) Error() string {
 	sb.WriteString("Please manually fix the following problems:\n\n")
 
 	for i, problem := range e.state.problems {
-		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, problem))
+		fmt.Fprintf(&sb, "%d. %s\n", i+1, problem)
 	}
 
 	sb.WriteString("\nCurrent /etc/hosts content:\n")
@@ -39,8 +39,8 @@ func (e *hostsFileCorruptedError) Error() string {
 	sb.WriteString("\nTo fix:\n")
 	sb.WriteString("1. Manually edit /etc/hosts with sudo, like `sudo vim -u NONE /etc/hosts`\n")
 	sb.WriteString("2. Remove all lines between and including:\n")
-	sb.WriteString(fmt.Sprintf("     %s\n", markerStart))
-	sb.WriteString(fmt.Sprintf("     %s\n", markerEnd))
+	fmt.Fprintf(&sb, "     %s\n", markerStart)
+	fmt.Fprintf(&sb, "     %s\n", markerEnd)
 	sb.WriteString("3. Run kubectl-localmesh again\n")
 
 	return sb.String()

--- a/internal/log/summary.go
+++ b/internal/log/summary.go
@@ -66,8 +66,8 @@ func GenerateSummary(services []ServiceSummary, listenerPort port.ListenerPort) 
 		for _, svc := range httpServices {
 			p := svc.EffectiveListenPort(listenerPort)
 			protocolLabel := formatProtocolLabel(svc.Protocol)
-			sb.WriteString(fmt.Sprintf("  • http://%s:%d (%s) -> %s\n",
-				svc.Host, p, protocolLabel, svc.Backend))
+			fmt.Fprintf(&sb, "  • http://%s:%d (%s) -> %s\n",
+				svc.Host, p, protocolLabel, svc.Backend)
 		}
 		sb.WriteString("\n")
 	}
@@ -77,8 +77,8 @@ func GenerateSummary(services []ServiceSummary, listenerPort port.ListenerPort) 
 		sb.WriteString("  TCP Services:\n")
 		for _, svc := range tcpServices {
 			p := svc.EffectiveListenPort(listenerPort)
-			sb.WriteString(fmt.Sprintf("  • tcp://%s:%d -> %s\n",
-				svc.Host, p, svc.Backend))
+			fmt.Fprintf(&sb, "  • tcp://%s:%d -> %s\n",
+				svc.Host, p, svc.Backend)
 		}
 		sb.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary
- golangci-lint v2.7.2 (built with go1.25.4) panicked during lint with `file requires newer Go version go1.26` when analyzing code compiled with go1.26.0
- Updated golangci-lint to v2.10.1 (built with go1.26.0) via aqua
- Fixed 5 new staticcheck QF1012 warnings: replaced `WriteString(Sprintf(...))` with `fmt.Fprintf` in `internal/hosts/validate.go` and `internal/log/summary.go`

## Test plan
- [x] `task test` passes
- [x] `task lint` passes with 0 issues
- [x] No panic on stop hook execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)